### PR TITLE
Update OAuth help doc to include OAuth2 plugin

### DIFF
--- a/content/developer/framework/oauth.md
+++ b/content/developer/framework/oauth.md
@@ -1,0 +1,97 @@
+---
+title: OAuth
+tags:
+- Developers
+- Framework
+category: developer
+menu:
+  developer:
+    parent: framework
+aliases:
+- /developers/framework/oauth
+---
+
+## SSO with OAuth: Overview
+
+Vanilla currently provides OAuth2 integrations with these third-party services as ready-to-go addons:
+
+* Facebook
+* Twitter
+* LinkedIn
+* Google+
+
+Because OAuth 2.0 is an SSO *framework* and not a narrowly defined protocol (see [OAuth 2.0 Spec](https://tools.ietf.org/html/rfc6749)), custom services work is typically required to set up an OAuth solution for your forum. In an attempt to minimize the amount of custom services required to create SSO integrations, Vanilla has created a base class that can easily be extended by custom plugins. This base class might look like many of our plugins (containing event handlers, etc.) it is not intended to be executed directly. To take advantage of this class, either use our **OAuth2 Plugin** or **Create Your Own OAuth2 Plugin**. 
+
+## OAuth2 Plugin
+
+### Overview
+
+Vanilla has created an OAuth2 plugin that, for most use-cases, can provide a plug-and-play SSO solution.
+
+OAuth2 accounts are mapped to existing forum accounts by email address, or a new account is created if no match is found.
+
+### Workflow
+
+This plugin has a workflow of three distinct steps:
+
+ * An **authorization request** (request for a code)
+ * A **token request** (the code is exchanged for an authorization token)
+ * A **profile request** (by passing the authoriztion token)
+
+### Assumptions
+
+Besides requiring that you follow the workflow above, this plugin has several assumptions about the setup of the Authorization Server. If your Authorization Server does not meet these assumptions it does not mean that you cannot integrate with a Vanilla forum, it means that you will not be able to use this plugin out of the box and that you will requires some level of customization.
+
+ * All requests from Vanilla are sent with the header `Content-Type: application/x-www-form-urlencoded`
+ * The Authorization Server will expect an authorization request sent by GET with the following parameters:
+  * `response_type` => `code`
+  * `client_id`
+  * `redirect_uri` => https://*[The url of the forum]*/entry/oauth2
+  * `scope`
+  * `state`
+ * The Authorization Server will respond to a successful log in by sending a `code` through GET to the `redirect_uri`
+ * The Authorization Server will expect a token request sent by POST with the following parameters:
+  * `code` => *[the code returned from the authorization request]*
+  * `client_id`
+  * `client_secret`
+  * `redirect_uri` => https://*[The url of the forum]*/entry/oauth2
+  * `grant_type` => `authorization_code`
+  * `scope`
+ * The Authorization Server will send a JSON response with the variable `access_token`
+ * The Authorization Server will accept a request for the user's profile sent by GET with `access_token`
+ * The Authorization Server will send a JSON response with at least the following:
+  * A uniqueID for the user
+  * the user's email
+  * the user's name (display name, nickname)
+
+**NOTE**: Not supported in this work flow are **"nonce" support** (a hash sent in the `state` and verified to be unchanged) and **refresh tokens**.
+
+### Features
+
+The OAuth2 Plugin attempts to "parameterize" as many aspects of the functionality as possible. A settings form in the dashboard allows you to set:
+
+ * The client id
+ * The client secret
+ * The full path to the authorization URI, registration uri, sign out uri, token endpoint and profile endpoint
+ * The scope
+ * The exepected keys in the json response in the profile request
+
+### Possible Pitfalls
+
+A number of things can go wrong when trying to implement SSO with this plugin:
+
+ * Double check that all the parameters outlined in the Assumptions section above are met
+ * Your forum must be accessed over `https` and must contact your Authorization Server in the same way
+ * Your Authorization Server will usually need to "whitelist" the redirect URI (i.e. https://*[The url of the forum]*/entry/oauth2)
+
+## Create Your Own OAuth2 Plugin
+
+For more on how to create your own plugin see our docs on [Plugins](/developer/plugins/). 
+
+Feel free to use the OAuth2 plugin as a template. Make sure your plugin extends Gdn_OAuth2. You may want to change your ProviderKey (the key used to store your configuration data in the db) to something unique:
+
+`$this->setProviderKey('myOauthConnection');`
+
+This key will appear as part of a URL on the public facing site when users connect so you will want to make it relevant, readable and url safe.
+
+Now you can override any of the methods or constants in Gdn_OAuth2 or create new hooks for added functionality.

--- a/content/help/sso/oauth/index.md
+++ b/content/help/sso/oauth/index.md
@@ -15,8 +15,6 @@ aliases:
 
 ## SSO with OAuth: Overview
 
-Because OAuth 2.0 is an SSO *framework* and not a narrowly defined protocol, custom services work is typically required to set up an OAuth solution for your forum.
-
 Vanilla currently provides OAuth2 integrations with these third-party services as ready-to-go addons:
 
 * Facebook
@@ -24,4 +22,66 @@ Vanilla currently provides OAuth2 integrations with these third-party services a
 * LinkedIn
 * Google+
 
-Contact the Vanilla Support Team for more information.
+Because OAuth 2.0 is an SSO *framework* and not a narrowly defined protocol (see https://tools.ietf.org/html/rfc6749), custom services work is typically required to set up an OAuth solution for your forum. In an attpempt to minimize the amount of custom services required to create SSO integrations, Vanilla has created a base class that can easily be extended by custom plugins. This base class might look like many of our plugins (containing event handlers, etc.) it is not intended to be executed directly. To take advantage of this class, either create a plug in to extend its features or use the OAuth2 plugin. 
+
+## OAuth2 Plugin
+ 
+### Overview
+
+Vanilla has created an OAuth2 plugin that, for most use-cases, can provide a plug-and-play SSO solution.
+
+OAuth2 accounts are mapped to existing forum accounts by email address, or a new account is created if no match is found.
+
+### Workflow 
+ 
+This plugin has a workflow of three distinct steps:
+  
+ * An **authorization request** (request for a code)
+ * A **token request** (the code is exchanged for an authorization token)
+ * A **profile request** (by passing the authoriztion token)
+  
+### Assumptions
+
+Besides requiring that you follow the workflow above, this plugin has several assumptions about the setup of the Authorization Server. If your Authorization Server does not meet these assumptions it does not mean that you cannot integrate with a Vanilla forum, it means that you will not be able to use this plugin out of the box and that you will requires some level of customization.
+
+ * All requests from Vanilla are sent with the header `Content-Type: application/x-www-form-urlencoded`
+ * The Authorization Server will expect an authorization request sent by GET with the following parameters:
+  * `response_type` => `code`
+  * `client_id`
+  * `redirect_uri` => https://*[The url of the forum]*/entry/oauth2
+  * `scope`
+  * `state`
+ * The Authorization Server will respond to a successful log in by sending a `code` through GET to the `redirect_uri`
+ * The Authorization Server will expect a token request sent by POST with the following parameters:
+  * `code` => *[the code returned from the authorization request]*
+  * `client_id`
+  * `client_secret`
+  * `redirect_uri` => https://*[The url of the forum]*/entry/oauth2
+  * `grant_type` => `authorization_code`
+  * `scope`
+ * The Authorization Server will send a JSON response with the variable `access_token`
+ * The Authorization Server will accept a request for the user's profile sent by GET with `access_token`
+ * The Authorization Server will send a JSON response with at least the following:
+  * A uniqueID for the user
+  * the user's email
+  * the user's name (display name, nickname)
+ 
+**NOTE**: Not supported in this work flow are **"nonce" support** (a hash sent in the `state` and verified to be unchanged) and **refresh tokens**.
+
+### Features
+
+The OAuth2 Plugin attempts to "parameterize" as many aspects of the functionality as possible. A settings form in the dashboard allows you to set:
+ 
+ * The client id
+ * The client secret
+ * The full path to the authorization URI, registration uri, sign out uri, token endpoint and profile endpoint
+ * The scope
+ * The exepected keys in the json response in the profile request
+
+### Possible Pitfalls
+
+A number of things can go wrong when trying to implement SSO with this plugin:
+
+ * Double check that all the parameters outlined in the Assumptions section above are met
+ * Your forum must be accessed over `https` and must contact your Authorization Server in the same way
+ * Your Authorization Server will usually need to "whitelist" the redirect URI (i.e. https://*[The url of the forum]*/entry/oauth2)

--- a/content/help/sso/oauth/index.md
+++ b/content/help/sso/oauth/index.md
@@ -22,7 +22,7 @@ Vanilla currently provides OAuth2 integrations with these third-party services a
 * LinkedIn
 * Google+
 
-Because OAuth 2.0 is an SSO *framework* and not a narrowly defined protocol (see https://tools.ietf.org/html/rfc6749), custom services work is typically required to set up an OAuth solution for your forum. In an attpempt to minimize the amount of custom services required to create SSO integrations, Vanilla has created a base class that can easily be extended by custom plugins. This base class might look like many of our plugins (containing event handlers, etc.) it is not intended to be executed directly. To take advantage of this class, either create a plug in to extend its features or use the OAuth2 plugin. 
+Because OAuth 2.0 is an SSO *framework* and not a narrowly defined protocol (see [OAuth 2.0 Spec](https://tools.ietf.org/html/rfc6749)), custom services work is typically required to set up an OAuth solution for your forum. In an attpempt to minimize the amount of custom services required to create SSO integrations, Vanilla has created a base class that can easily be extended by custom plugins. This base class might look like many of our plugins (containing event handlers, etc.) it is not intended to be executed directly. To take advantage of this class, either create a plug in to extend its features or use the OAuth2 plugin. 
 
 ## OAuth2 Plugin
  

--- a/content/help/sso/oauth/index.md
+++ b/content/help/sso/oauth/index.md
@@ -32,51 +32,15 @@ Vanilla has created an OAuth2 plugin that, for most use-cases, can provide a plu
 
 OAuth2 accounts are mapped to existing forum accounts by email address, or a new account is created if no match is found.
 
-### Workflow 
- 
-This plugin has a workflow of three distinct steps:
-  
- * An **authorization request** (request for a code)
- * A **token request** (the code is exchanged for an authorization token)
- * A **profile request** (by passing the authoriztion token)
-  
-### Assumptions
-
-Besides requiring that you follow the workflow above, this plugin has several assumptions about the setup of the Authorization Server. If your Authorization Server does not meet these assumptions it does not mean that you cannot integrate with a Vanilla forum, it means that you will not be able to use this plugin out of the box and that you will requires some level of customization.
-
- * All requests from Vanilla are sent with the header `Content-Type: application/x-www-form-urlencoded`
- * The Authorization Server will expect an authorization request sent by GET with the following parameters:
-  * `response_type` => `code`
-  * `client_id`
-  * `redirect_uri` => https://*[The url of the forum]*/entry/oauth2
-  * `scope`
-  * `state`
- * The Authorization Server will respond to a successful log in by sending a `code` through GET to the `redirect_uri`
- * The Authorization Server will expect a token request sent by POST with the following parameters:
-  * `code` => *[the code returned from the authorization request]*
-  * `client_id`
-  * `client_secret`
-  * `redirect_uri` => https://*[The url of the forum]*/entry/oauth2
-  * `grant_type` => `authorization_code`
-  * `scope`
- * The Authorization Server will send a JSON response with the variable `access_token`
- * The Authorization Server will accept a request for the user's profile sent by GET with `access_token`
- * The Authorization Server will send a JSON response with at least the following:
-  * A uniqueID for the user
-  * the user's email
-  * the user's name (display name, nickname)
- 
-**NOTE**: Not supported in this work flow are **"nonce" support** (a hash sent in the `state` and verified to be unchanged) and **refresh tokens**.
-
 ### Features
 
 The OAuth2 Plugin attempts to "parameterize" as many aspects of the functionality as possible. A settings form in the dashboard allows you to set:
  
  * The client id
  * The client secret
- * The full path to the authorization URI, registration uri, sign out uri, token endpoint and profile endpoint
+ * The full path to the authorization URI, registration URI, sign out URI, token endpoint and profile endpoint
  * The scope
- * The exepected keys in the json response in the profile request
+ * The exepected keys in the JSON response in the profile request
 
 ### Possible Pitfalls
 


### PR DESCRIPTION
Up until now our OAuth doc only told users that they could connect to third-party providers using OAuth2. We have since added a base class which developers can extend to build custom OAuth plugins. We have also added our own OAuth2 plugin that can be used to create SSO connections "out of the box".

This pull request updates the help docs giving an overview, the assumptions, and features of the plugin.