### PR TITLE
Update links from vanillaforums.org to open.vanillaforums.com

### DIFF
--- a/content/developer/backend/index.md
+++ b/content/developer/backend/index.md
@@ -45,7 +45,7 @@ In **Vanilla 2.3**, these rules change because the `p` parameter has been remove
 
 ### IIS
 
-We do not officially support this server, but information and help may be provided on our [community forum](https://vanillaforums.org/discussions). We welcome additions to this documentation.
+We do not officially support this server, but information and help may be provided on our [community forum](https://open.vanillaforums.com). We welcome additions to this documentation.
 
 ## Caching
 

--- a/content/developer/changelog/index.md
+++ b/content/developer/changelog/index.md
@@ -16,7 +16,7 @@ Release notes
 ## 2.1
 
 ### 2.1.6
-*[Released 21 Nov 2014](http://vanillaforums.org/discussion/28555/vanilla-2-1-6-released)*
+*[Released 21 Nov 2014](https://open.vanillaforums.com/discussion/28555/vanilla-2-1-6-released)*
 
 * Security: Fixes an SQL injection vector.
 * Security: Adds a PDO option to harden against SQL injection.
@@ -24,7 +24,7 @@ Release notes
 * Adds vBulletin 5.1 password hashing to allow seamless password migrations. All previous versions continue to be supported.
 
 ### 2.1.5
-*[Released 31 Oct 2014](http://vanillaforums.org/discussion/28337/vanilla-2-1-5-released-and-2-0-18-14)*
+*[Released 31 Oct 2014](https://open.vanillaforums.com/discussion/28337/vanilla-2-1-5-released-and-2-0-18-14)*
 
 * Security: An Insecure Direct Object Reference was fixed that allowed unauthorized comment editing.
 * Security: Potential CSRF vectors were closed, including one that could allow account hijacking.
@@ -35,7 +35,7 @@ Release notes
 * 2.1.4 had a merge conflict which this release replaced.
 
 ### 2.1.3
-*[Released 9 Sept 2014](http://vanillaforums.org/discussion/27822/vanilla-2-1-3-security-release)*
+*[Released 9 Sept 2014](https://open.vanillaforums.com/discussion/27822/vanilla-2-1-3-security-release)*
 
 * 3 newly discovered XSS vectors were fixed.
 * The timezone bug introduced in 2.1.1 is fixed.
@@ -44,7 +44,7 @@ Release notes
 
 ### 2.1.1
 
-*[Released 2 Aug 2014](http://vanillaforums.org/discussion/27540/vanilla-2-1-1-important-security-bug-release)*
+*[Released 2 Aug 2014](https://open.vanillaforums.com/discussion/27540/vanilla-2-1-1-important-security-bug-release)*
 
 
 * HtmLawed was upgraded to close an XSS vector (thanks to Psych0tr1a for responsibly disclosing this to us & to HtmLawed for a fast patch in response).
@@ -61,7 +61,7 @@ Release notes
 
 ### 2.1
 
-*[Released 28 April 2014](http://vanillaforums.org/discussion/26685/vanilla-2-1-stable-released)*
+*[Released 28 April 2014](https://open.vanillaforums.com/discussion/26685/vanilla-2-1-stable-released)*
 
 Vanilla internals were completely revamped for 2.1. Many views and several plugin hooks were changed, so **themes and plugins must be tested** and may need to be refactored before upgrading.
 
@@ -72,23 +72,23 @@ Vanilla internals were completely revamped for 2.1. Many views and several plugi
 * Framework improvements.
 * Hundreds of bug fixes.
 
-Incremental changelogs from the [first 2.1 beta](http://vanillaforums.org/discussion/23322/vanilla-2-1b1-released) thru RC1 can be found in their individual release announcements:
+Incremental changelogs from the [first 2.1 beta](https://open.vanillaforums.com/discussion/23322/vanilla-2-1b1-released) thru RC1 can be found in their individual release announcements:
 
-* [Beta 2](http://vanillaforums.org/discussion/24845/vanilla-2-1b2-released)
-* [Beta 3](http://vanillaforums.org/discussion/26518/vanillla-2-1-beta-3)
-* [Release Candidate 1](http://vanillaforums.org/discussion/26626/vanilla-2-1-release-candidate)
+* [Beta 2](https://open.vanillaforums.com/discussion/24845/vanilla-2-1b2-released)
+* [Beta 3](https://open.vanillaforums.com/discussion/26518/vanillla-2-1-beta-3)
+* [Release Candidate 1](https://open.vanillaforums.com/discussion/26626/vanilla-2-1-release-candidate)
 
 ## 2.0.18
 
 ### 2.0.18.14
-*[Released 30 Oct 2014](http://vanillaforums.org/discussion/28337/vanilla-2-1-5-released-and-2-0-18-14)*
+*[Released 30 Oct 2014](https://open.vanillaforums.com/discussion/28337/vanilla-2-1-5-released-and-2-0-18-14)*
 
 * Security: An Insecure Direct Object Reference was fixed that allowed unauthorized comment editing.
 * Security: Potential CSRF vectors were closed, including one that could allow account hijacking.
 * Fixes DeliveryType issue in plugins managements.
 
 ### 2.0.18.13
-*[Released 5 Aug 2014](http://vanillaforums.org/discussion/27541/vanilla-2-0-18-13-security-release-for-old-2-0-18-installs)*
+*[Released 5 Aug 2014](https://open.vanillaforums.com/discussion/27541/vanilla-2-0-18-13-security-release-for-old-2-0-18-installs)*
 
 * HtmLawed is upgraded and its filtering tightened (thanks @x00 & Psych0tr1a)
 * parseJSON() is substituted for eval() in 2 places
@@ -96,18 +96,18 @@ Incremental changelogs from the [first 2.1 beta](http://vanillaforums.org/discus
 * Fixes HTMLawed error in 2.0.18.12 which this immediately replaced.
 
 ### 2.0.18.11  
-*[Released 21 Apr 2014](http://vanillaforums.org/discussion/26627/vanilla-2-0-18-11-security-release)*
+*[Released 21 Apr 2014](https://open.vanillaforums.com/discussion/26627/vanilla-2-0-18-11-security-release)*
 
 * 3 security patches.
 * Ditches troublesome "Remove" option on the plugins page.
 
 ### 2.0.18.10
-*[Released 21 Dec 2013](http://vanillaforums.org/discussion/25668/dec-2013-security-update-2-0-18-10-and-2-1b2)*
+*[Released 21 Dec 2013](https://open.vanillaforums.com/discussion/25668/dec-2013-security-update-2-0-18-10-and-2-1b2)*
 
 * Removes flawed update checker.
 
 ### 2.0.18.9
-*[Released 26 Nov 2013](http://vanillaforums.org/discussion/25458/security-update-vanilla-2-0-18-9)*
+*[Released 26 Nov 2013](https://open.vanillaforums.com/discussion/25458/security-update-vanilla-2-0-18-9)*
 
 * Use SafeRedirect() instead of Redirect() in the discussion controller.
 * Added TrustedDomains() and SafeRedirect().
@@ -120,7 +120,7 @@ Incremental changelogs from the [first 2.1 beta](http://vanillaforums.org/discus
 * Do not add linebreaks twice on search.
 
 ### 2.0.18.8
-*[Released 4 Apr 2013](http://vanillaforums.org/discussion/23339/security-update-vanilla-2-0-18-8)*
+*[Released 4 Apr 2013](https://open.vanillaforums.com/discussion/23339/security-update-vanilla-2-0-18-8)*
 
 * Call & check for FilterForm() properly.
 
@@ -145,18 +145,18 @@ Incremental changelogs from the [first 2.1 beta](http://vanillaforums.org/discus
 * Added joomla password hashing.
 
 ### 2.0.18.4
-*[Released 26 Mar 2012](http://vanillaforums.org/discussion/19542/vanilla-2-0-18-4-released)*
+*[Released 26 Mar 2012](https://open.vanillaforums.com/discussion/19542/vanilla-2-0-18-4-released)*
 
 * Patch form tampering possibility.
 * Fix canonical URL issues.
 
 ### 2.0.18.3
-*[Released 5 Mar 2012](http://vanillaforums.org/discussion/19285/security-vulnerability-flagging-plugin-2-0-18-2-and-earlier)*
+*[Released 5 Mar 2012](https://open.vanillaforums.com/discussion/19285/security-vulnerability-flagging-plugin-2-0-18-2-and-earlier)*
 
 * Flagging plugin security fixes.
 
 ### 2.0.18.2
-*[Released 21 Jan 2012](http://vanillaforums.org/discussion/18749/vanilla-2-0-18-2-release)*
+*[Released 21 Jan 2012](https://open.vanillaforums.com/discussion/18749/vanilla-2-0-18-2-release)*
 
 * Fixed bug where Gravatar was using name instead of email for Vanillicons.
 * vBulletin import improvements.
@@ -167,7 +167,7 @@ Incremental changelogs from the [first 2.1 beta](http://vanillaforums.org/discus
 * Various other bug fixes.
 
 ### 2.0.18.1
-*[Released 7 Nov 2011](http://vanillaforums.org/discussion/17643/vanilla-2-0-18-final-release)*
+*[Released 7 Nov 2011](https://open.vanillaforums.com/discussion/17643/vanilla-2-0-18-final-release)*
 
 * Fixed bug in the Twitter plugin.
 * Fixed some bugs with connecting.
@@ -179,7 +179,7 @@ Incremental changelogs from the [first 2.1 beta](http://vanillaforums.org/discus
 * Fixed jQuery syntax errors.
 
 ### 2.0.18
-*[Released 3 Nov 2011](http://vanillaforums.org/discussion/17643/vanilla-2-0-18-final-release)*
+*[Released 3 Nov 2011](https://open.vanillaforums.com/discussion/17643/vanilla-2-0-18-final-release)*
 
 Major Features:
 

--- a/content/developer/community/index.md
+++ b/content/developer/community/index.md
@@ -11,19 +11,19 @@ aliases:
 ---
 ## Developers Community
 
-We have a vibrant [developers' community at vanillaforums.org](http://vanillaforums.org/discussions/). Please register there to ask general questions, contribute feedback and ideas, help others, add your own plugins & themes to the [official directory](http://vanillaforums.org/addons), and sign the [contributors' agreement](http://vanillaforums.org/contributors).
+We have a vibrant [developers' community](https://open.vanillaforums.com). Please register there to ask general questions, contribute feedback and ideas, help others, add your own plugins & themes to the [official directory](https://open.vanillaforums.com/addons), and sign the [contributors' agreement](https://open.vanillaforums.com/contributors).
 
 ### Get Notified
 
 Want to get notified about the newest releases?
 
-* Sign up for the VanillaForums.org newsletter in [your community profile](http://vanillaforums.org/profile/edit).
-* Watch the [RSS feed for the 'blog' category](http://vanillaforums.org/categories/blog/feed.rss).
+* Sign up for the VanillaForums.org newsletter in [your community profile](https://open.vanillaforums.com/profile/edit).
+* Watch the [RSS feed for the 'blog' category](https://open.vanillaforums.com/categories/blog/feed.rss).
 * Follow our [Twitter account](http://twitter.com/vanilla).
 
 ### Plugins
 
-These addons are currently used on vanillaforums.org. The addons with an asterisk are currently only available on our cloud hosting but may have near-equivalents available from the community.
+These addons are currently used on our [community forum](https://open.vanillaforums.com). The addons with an asterisk are currently only available on our cloud hosting but may have near-equivalents available from the community.
 
 * Tagging
 * Reactions*
@@ -42,4 +42,4 @@ These addons are currently used on vanillaforums.org. The addons with an asteris
 
 ### Theme
 
-The theme used on vanillaforums.org is custom and is not open source. We want it to continue looking unique!
+The theme used on the community forum is custom and is not open source. We want it to continue looking unique!

--- a/content/developer/contributing/index.md
+++ b/content/developer/contributing/index.md
@@ -14,20 +14,20 @@ aliases:
 
 ### General
 
-1. Welcome folks to the [community](http://vanillaforums.org/discussions) and be awesome!
+1. Welcome folks to the [community](https://open.vanillaforums.com) and be awesome!
 1. Answer questions.
 1. Report [issues](https://github.com/vanillaforums/vanilla) like a pro (see below).
 1. [Triage](#triaging-issues) issues already reported!
-1. Test [pre-releases](http://vanillaforums.org/categories/blog).
-1. Contribute [docs](https://github.com/vanillaforums/VanillaDocs).
+1. Test [pre-releases](https://open.vanillaforums.com/categories/blog).
+1. Contribute [docs](https://github.com/vanilla/docs).
 1. Help [translate Vanilla](/developer/locales).
 1. Evaluate community addons & offer feedback.
 1. Do accessibility testing! Unplug your mouse, turn on a screen reader, and see what it's like to use Vanilla.
 
 ### Developers
 
-1. Contribute code via [pull requests](/developer/contributing/pull-requests) (requires [Contributor Agreement](http://vanillaforums.org/contributors))
-1. Contribute addons & themes to the [Official Directory](http://vanillaforums.org/addons).
+1. Contribute code via [pull requests](/developer/contributing/pull-requests) (requires [Contributor Agreement](https://open.vanillaforums.com/contributors))
+1. Contribute addons & themes to the [Official Directory](https://open.vanillaforums.com/addons).
 1. Audit code for security & disclose issues [responsibly](/developers).
 
 Sections of our contribution guidelines are adapted or copied from [Swift](https://swift.org/contributing/) because they are awesome.

--- a/content/developer/contributing/pull-requests.md
+++ b/content/developer/contributing/pull-requests.md
@@ -38,7 +38,7 @@ Never try to address multiple, unrelated issues in a single pull request.
 
 ### Pull request checklist
 
-* Have you signed the [contributors' agreement](http://vanillaforums.org/contributors)?
+* Have you signed the [contributors' agreement](https://open.vanillaforums.com/contributors)?
 * Did you target the correct branch (usually `master`)?
 * Is your title written like a concise release note?
 * Does your description provide rationale for your change?

--- a/content/developer/framework/index.md
+++ b/content/developer/framework/index.md
@@ -61,4 +61,4 @@ The Skeleton application in `/applications/skeleton` is heavily documented inlin
 
 ## Where to start
 
-Not sure what doc to read next? We recommend reading the [plugin quickstart](/developer/plugins/quickstart), then try [Controller](/developer/framework/controllers) and [Models](/developer/framework/models). It's a self-guided tour from there! Don't forget to stop by the [community forum](http://vanillaforums.org/discussions) for guidance. When in doubt, dance.
+Not sure what doc to read next? We recommend reading the [plugin quickstart](/developer/plugins/quickstart), then try [Controller](/developer/framework/controllers) and [Models](/developer/framework/models). It's a self-guided tour from there! Don't forget to stop by the [community forum](https://open.vanillaforums.com) for guidance. When in doubt, dance.

--- a/content/developer/importing/index.md
+++ b/content/developer/importing/index.md
@@ -14,7 +14,7 @@ aliases:
 
 Already have a community on another platform? Great! We have a tool called Vanilla Porter that can help you migrate from many other popular platforms.
 
-[Download Vanilla Porter](http://vanillaforums.org/addon/porter-core)
+[Download Vanilla Porter](https://open.vanillaforums.com/addon/porter-core)
 
 Vanilla Porter is a tool that you can upload to your current web server to run in your web browser. It exports any platform to a generic format that the "Import" option in your new Vanilla Forum can read.
 

--- a/content/developer/importing/porter.md
+++ b/content/developer/importing/porter.md
@@ -12,7 +12,7 @@ aliases:
 ---
 ## Migrating a forum to Vanilla
 
-Vanilla Porter is the [export tool](http://vanillaforums.org/addon/porter-core)  for converting your legacy forum to Vanilla. The process is four steps:
+Vanilla Porter is the [export tool](https://open.vanillaforums.com/addon/porter-core)  for converting your legacy forum to Vanilla. The process is four steps:
 
 1. Export your old forum data to a special "Porter file".
 2. Create a new Vanilla forum.
@@ -47,7 +47,7 @@ If you have a very large forum (millions of posts), see the **Special Steps & No
 
 To use it:
 
-1. **Grab** the [export tool](http://vanillaforums.org/addon/porter-core) and unzip it. It will be a single file named `vanilla2export.php`.
+1. **Grab** the [export tool](https://open.vanillaforums.com/addon/porter-core) and unzip it. It will be a single file named `vanilla2export.php`.
 
 1. **Upload** the file to *writable* web directory on the server with your legacy database. Most forums have a `files` or `uploads` directory which is an easy place to put it.
 
@@ -64,7 +64,7 @@ Got problems? See the **Troubleshooting** section below.
 
 ### 2. Create a new Vanilla forum
 
-In order to import your data, you will need a fresh installation of [Vanilla](http://vanillaforums.org/addon/vanilla-core). When you do the import, all data in your fresh installation will be overwritten, so make sure you don’t have any discussions you want to keep there. See the README file for help.
+In order to import your data, you will need a fresh installation of [Vanilla](https://open.vanillaforums.com/addon/vanilla-core). When you do the import, all data in your fresh installation will be overwritten, so make sure you don’t have any discussions you want to keep there. See the README file for help.
 
 
 ### 3. Import your data
@@ -124,7 +124,7 @@ File attachments and avatars may be stored in the file system or as binary blobs
 
 The Porter can export binary blobs for vBulletin. When navigating to the `vanilla2export.php` file, add `?avatars=1&files=1` to the URL. This will create folders for `attachments` and `customavatars` that should each be directly copied to Vanilla's `uploads` folder.
 
-To rename vBulletin's attachments to have correct extensions, use `filepath=/path/to/attachments` in the URL to process them. Renaming phpBB's attachments requires the special `utilities/phpbb.extensions.php` file in the repository. These are currently advanced user tools and may require consulting the inline documentation in the appropriate package file. If you get stuck, ask on the [community forum](http://vanillaforums.org/discussions).
+To rename vBulletin's attachments to have correct extensions, use `filepath=/path/to/attachments` in the URL to process them. Renaming phpBB's attachments requires the special `utilities/phpbb.extensions.php` file in the repository. These are currently advanced user tools and may require consulting the inline documentation in the appropriate package file. If you get stuck, ask on the [community forum](https://open.vanillaforums.com).
 
 
 #### Non-MySQL data
@@ -209,7 +209,7 @@ To help set this up you you can use the `forum-redirector` folder in the [Addons
 1. Attempting to export from an MSSQL database. You must first convert to MySQL. Try the [dbdump tool](https://github.com/tburry/dbdump).
 1. Attempting to export from a non-PHP server. Try setting up a tool like MAMP or WAMP on your computer and copying your database there instead.
 
-Still having trouble? Ask on the [community forum](http://vanillaforums.org/discussions).
+Still having trouble? Ask on the [community forum](https://open.vanillaforums.com).
 
 
 #### Common problems while importing
@@ -220,14 +220,14 @@ Still having trouble? Ask on the [community forum](http://vanillaforums.org/disc
 1. Not placing the generated porter file directly in the `uploads` folder.
 1. Attempting to 'Browse' for the file rather than selecting it with the multiple choice selector above that.
 
-Still having trouble? Ask on the [community forum](http://vanillaforums.org/discussions).
+Still having trouble? Ask on the [community forum](https://open.vanillaforums.com).
 
 
 #### Data missing
 
 Review the support table included in the vanilla2export.php file (by browsing to it in a web browser and clicking the link) and verify that data is included in that platform.
 
-**Is it supported?** If so, ask on the [community forum](http://vanillaforums.org/discussions). If you can find the technical reason it didn't work, please file an [issue on the GitHub repository](https://github.com/vanilla/porter/issues).
+**Is it supported?** If so, ask on the [community forum](https://open.vanillaforums.com). If you can find the technical reason it didn't work, please file an [issue on the GitHub repository](https://github.com/vanilla/porter/issues).
 
 **Not supported?** You can request support be added on the GitHub repository. If you do this, *please be prepared to supply a copy of your forum database* as a sample. For password support, first create a new user with a password you can share for testing purposes.
 

--- a/content/developer/importing/support.md
+++ b/content/developer/importing/support.md
@@ -12,7 +12,7 @@ aliases:
 ---
 ## Supported platforms
 
-Migration tools are available for the following platforms. All migration tools minimally support users, categories, discussions, and comments. For a current per-platform, per-feature support list, see the [Vanilla Porter](http://vanillaforums.org/addon/porter-core).
+Migration tools are available for the following platforms. All migration tools minimally support users, categories, discussions, and comments. For a current per-platform, per-feature support list, see the [Vanilla Porter](https://open.vanillaforums.com/addon/porter-core).
 
 ### PHP forums
 

--- a/content/developer/locales/index.md
+++ b/content/developer/locales/index.md
@@ -25,7 +25,7 @@ Want to help translate? Awesome! Here are some tips for creating great translati
 
 ## Installing locales
 
-1. Download the locale you want from the [Addon Directory](http://vanillaforums.org/addon/browse/locales/popular/2).
+1. Download the locale you want from the [Addon Directory](https://open.vanillaforums.com/addon/browse/all/popular/recent/).
 2. Upload the folder to your `locales` folder.
 3. In the Dashboard, go to `Addons > Locales`.
 4. Enable the locale.
@@ -33,7 +33,7 @@ Want to help translate? Awesome! Here are some tips for creating great translati
 
 ## Using multiple locales
 
-The [Multilingual plugin](http://vanillaforums.org/addon/multilingual-plugin) allows each user select their preference from all enabled locales.
+The [Multilingual plugin](https://open.vanillaforums.com/addon/multilingual-plugin) allows each user select their preference from all enabled locales.
 
 ## Overriding locales
 

--- a/content/developer/plugins/quickstart.md
+++ b/content/developer/plugins/quickstart.md
@@ -13,15 +13,15 @@ aliases:
 ## Quickstart Links
 
 * Read about our hooks system: [Extending Vanilla with plugins](/developer/plugins)
-* Download the official [Example plugin](http://vanillaforums.org/addon/example-plugin)
-* Download other plugins from the [Addon Directory](http://vanillaforums.org/addons) and borrow their code.
-* Get help in the [developer community](http://vanillaforums.org/categories/developers)
+* Download the official [Example plugin](https://open.vanillaforums.com/addon/example-plugin)
+* Download other plugins from the [Addon Directory](https://open.vanillaforums.com/addons) and borrow their code.
+* Get help in the [developer community](https://open.vanillaforums.com/categories/developers)
 
 ## Quickstart Guide
 
 Vanilla is built on an object-oriented, MVC framework. If you're coming at this from a mostly function-based world like WordPress or Drupal, this might read like moonspeak. That's OK! Soak it up and ask questions on the forum after you follow this guide and play with the examples.
 
-Ready to code? Grab the [Example plugin](http://vanillaforums.org/addon/example-plugin) and use it below for an even quicker start. Hang onto your butts, here we go:
+Ready to code? Grab the [Example plugin](https://open.vanillaforums.com/addon/example-plugin) and use it below for an even quicker start. Hang onto your butts, here we go:
 
 1. Name your plugin.
 1. Define your plugin.
@@ -123,13 +123,13 @@ That whole definitions section probably didn't *seem* very quick, but you just d
 
 ### 3. Find your hooks
 
-Try the [Eventi plugin](http://vanillaforums.org/addon/eventi-plugin) to visualize where events are fired in Vanilla. Use the hooks in the [Example plugin](http://vanillaforums.org/addon/example-plugin) to see what they do.
+Try the [Eventi plugin](https://open.vanillaforums.com/addon/eventi-plugin) to visualize where events are fired in Vanilla. Use the hooks in the [Example plugin](https://open.vanillaforums.com/addon/example-plugin) to see what they do.
 
 Read the [plugin hooks tutorial](/developer/plugins) for more on how to override & extend Vanilla.
 
 Use an IDE and use the project search functionality to locate instances of `FireEvent` in the [core repo](http://github.com/vanilla/vanilla). Many doc blocks show what events are fired within their methods. Or, search for `_Handler` in the [addons repo](http://github.com/vanilla/addons) to see examples and common uses.
 
-Lastly, [find a plugin](http://vanillaforums.org/addon) that does something similar to what you're trying to do, and check out its code. Maybe between 3 or 4 plugins you can find a good portion of what you're trying to accomplish.
+Lastly, [find a plugin](https://open.vanillaforums.com/addons) that does something similar to what you're trying to do, and check out its code. Maybe between 3 or 4 plugins you can find a good portion of what you're trying to accomplish.
 
 ### 4. Write your code
 
@@ -214,4 +214,4 @@ Final tips:
 * **Use models** to access the database rather than writing your own queries. E.g.: Need discussions? Look at `DiscussionModel`.
 * Adding your own data to the database? Read about the [database query builder](/developer/framework/database).
 
-And, as always, ask the talented & helpful folks on our [community forum](http://vanillaforums.org/discussions) when you get stuck.
+And, as always, ask the talented & helpful folks on our [community forum](https://open.vanillaforums.com) when you get stuck.

--- a/content/help/cloud/leaving/index.md
+++ b/content/help/cloud/leaving/index.md
@@ -57,13 +57,13 @@ Please only request this once. We generally cannot coordinate a "final backup" o
 
 If you plan to continue using Vanilla on your own, there's both good news and bad. The good news is that we don't maintain a private fork of Vanilla. Therefore, your data will mostly work as-is without further data conversions. The bad news is it's a little more complicated than that.
 
-First, you may need to build the [latest version](https://github.com/vanilla/vanilla) of the code from GitHub (`master` branch). Try the [latest stable release](https://vanillaforums.org/addon/vanilla-core) of Vanilla first, but if that doesn't work, you'll need to use Composer.
+First, you may need to build the [latest version](https://github.com/vanilla/vanilla) of the code from GitHub (`master` branch). Try the [latest stable release](https://open.vanillaforums.com/addon/vanilla-core) of Vanilla first, but if that doesn't work, you'll need to use Composer.
 
 Second, not all cloud-based addons are open source. There are open source alternatives for some, but you may need to convert the data yourself (We **do** provide any cloud-based addon data in your database). One example of this is Badges. 
 
 Thirdly, you may need to do some manual work to make existing file uploads appear correctly. You'll want to unzip what we send you into your `/uploads` folder if you're moving to open source. You may need to find and delete any instance of `cf:` or `~cf/` in file paths stored in the database (try `GDN_User.Photo` and `GDN_Media.Path`). These prefixes trigger a CDN lookup in our cloud environment. The open source default is the `/uploads` folder (which you should not need to prepend).
 
-You may find additional help from the [volunteer community](https://vanillaforums.org/discussions) and the [developer docs](/developer/).
+You may find additional help from the [volunteer community](https://open.vanillaforums.com) and the [developer docs](/developer/).
 
 ## Support
 

--- a/content/help/cloud/support/index.md
+++ b/content/help/cloud/support/index.md
@@ -27,4 +27,4 @@ Please know they **all go to exactly the same queue** for attention from our ent
 
 You will receive faster support and answers by using the methods above than emailing your account representative. After your forum is launched, we strongly recommend going directly to support for most needs to ensure the fastest turnaround.
 
-Please note the open source community forum at [vanillaforums.org](http://vanillaforums.org) (note the '.org' instead of '.com') is not an official support channel. While full of great volunteers, they are under no obligation to assist and may not be able to anyway.
+Please note the open source community forum at [open.vanillaforums.com](https://open.vanillaforums.com) is not an official support channel. While full of great volunteers, they are under no obligation to assist and may not be able to anyway.


### PR DESCRIPTION
I've replaced links going to the old community forum (vanillaforums.org) to the new address (open.vanillaforums.com) and changed some wording where necessary, mainly "VanillaForums.org" => "community forum"