### PR TITLE
Fix typo for "Kunena" and add more info to "Drupal Forum"

### DIFF
--- a/content/developer/importing/support.md
+++ b/content/developer/importing/support.md
@@ -25,8 +25,8 @@ Migration tools are available for the following platforms. All migration tools m
 * PunBB 1
 * IP.Board 3
 * XenForo
-* Joomla Kuena
-* Drupal Forum
+* Joomla Kunena
+* Drupal Advanced Forum
 * MyBB
 * esoTalk
 * Expression Engine


### PR DESCRIPTION
The forum module for Joomla is called [Kunena](https://extensions.joomla.org/extension/kunena/) and the drupal forum module which is support by the porter is [Advanced Forum](https://www.drupal.org/project/advanced_forum)