### PR TITLE
Fix formatting and class names in API v2 docs

### DIFF
--- a/content/developer/framework/apiv2/api-endpoints.md
+++ b/content/developer/framework/apiv2/api-endpoints.md
@@ -143,8 +143,8 @@ You can also return an object that implements **JsonSerializable**. An object li
     }
 
     // In your index() endpoint:
-    $out = $this-schema([
-            *:a => $this->getRowSchema('')
+    $out = $this->schema([
+            '*:a' => $this->getRowSchema('')
         ], __FUNCTION__, 'out');
 
     // In your get() endpoint:

--- a/content/developer/framework/apiv2/api-endpoints.md
+++ b/content/developer/framework/apiv2/api-endpoints.md
@@ -16,7 +16,7 @@ When writing an API controller class, each method represents an endpoint. How to
 
 ## The Controller Base Class
 
-Although controllers don't need to inherit from any class, the **Vanilla\Controller** class offers useful functionality and is going to be the class you inherit from almost 100% of the time. This guide assumes you are inheriting from that class and using its utility methods.
+Although controllers don't need to inherit from any class, the **Vanilla\Web\Controller** class offers useful functionality and is going to be the class you inherit from almost 100% of the time. This guide assumes you are inheriting from that class and using its utility methods.
 
 ## Dependency Injection
 

--- a/content/developer/framework/apiv2/resource-routing.md
+++ b/content/developer/framework/apiv2/resource-routing.md
@@ -83,7 +83,7 @@ Some parameters will be automatically mapped from request data. In order to map 
 - **array $query** will receive the query string as an array (`$_GET`).
 - **array $body** will receive the request body (`$_POST`).
 - **array $data** will receive a combination of the reflected method parameters, query string, and body. Use this to include the method parameters in a schema check.
-- **Garden\RequestInterface $*** will receive the request object.
+- **Garden\Web\RequestInterface $*** will receive the request object.
 - **...$*** variadics will receive the rest of the path.
 - **$path** is like the variadic, but will get a string (TODO).
 

--- a/content/developer/framework/apiv2/resource-routing.md
+++ b/content/developer/framework/apiv2/resource-routing.md
@@ -26,8 +26,8 @@ Currently, controllers do not support namespaces, but that is coming soon. When 
 
 When adding methods (actions) to your controllers their names determine what what type of request they'll map to. Here are the rules that determine which action is called.
 
-- <method>`()` maps with METHOD /controller (ex. DiscussionsApiController::post() maps with "POST /discussions").
-- <method>`_name()` maps with METHOD /controller/name (ex. ProfileApiController::get_activity() maps with "GET /profile/activity").
+- &lt;method&gt;`()` maps with METHOD /controller (ex. DiscussionsApiController::post() maps with "POST /discussions").
+- &lt;method&gt;`_name()` maps with METHOD /controller/name (ex. ProfileApiController::get_activity() maps with "GET /profile/activity").
 - `index()` maps with GET /controller.
 - `name()` maps with any HTTP method. Try to avoid such global actions.
 


### PR DESCRIPTION
This update fixes some syntax and formatting issues, in addition to correcting some class names.