### PR TITLE
Fix address to missing image on VanillaPop page in Help

### DIFF
--- a/content/help/addons/vanilla-pop/index.md
+++ b/content/help/addons/vanilla-pop/index.md
@@ -33,7 +33,7 @@ You can also set up additional email addresses to forward to individual categori
 
 When you have Vanilla Pop enabled you will see an __Incoming Email__ item in your dashboard under Site Settings. The page looks like this:
 
-![Vanilla Pop Settings](/img/help/addons/vanilla-pop/settings.png)
+![Vanilla Pop Settings](https://images.v-cdn.net/docs/vanillapop-settings.png)
 
 Let's run down the settings one by one:
 

--- a/content/help/addons/vanilla-pop/index.md
+++ b/content/help/addons/vanilla-pop/index.md
@@ -33,7 +33,7 @@ You can also set up additional email addresses to forward to individual categori
 
 When you have Vanilla Pop enabled you will see an __Incoming Email__ item in your dashboard under Site Settings. The page looks like this:
 
-![Vanilla Pop Settings](img/help/addons/vanilla-pop/settings.png)
+![Vanilla Pop Settings](/img/help/addons/vanilla-pop/settings.png)
 
 Let's run down the settings one by one:
 


### PR DESCRIPTION
Image URI was relative, the document was moved to a directory and the image was coming up not found. This PR will fix that .