### PR TITLE
Fix broken links in local development

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -312,8 +312,9 @@ module.exports = function (grunt) {
         args = [
             '--destination=./' + options.dest
         ];
-        if (target === 'dev') {rr
+        if (target === 'dev') {
             args.push('--config=' + path.resolve('./config-dev.yaml'));
+            args.push('--buildDrafts=true');
             args.push('--buildFuture=true');
         } else {
             args.push('--config=' + path.resolve('./config.yaml'));

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -314,7 +314,6 @@ module.exports = function (grunt) {
         ];
         if (target === 'dev') {
             args.push('--config=' + path.resolve('./config-dev.yaml'));
-            args.push('--baseUrl=http://127.0.0.1:8081');
             args.push('--buildDrafts=true');
             args.push('--buildFuture=true');
         } else {

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -312,9 +312,8 @@ module.exports = function (grunt) {
         args = [
             '--destination=./' + options.dest
         ];
-        if (target === 'dev') {
+        if (target === 'dev') {rr
             args.push('--config=' + path.resolve('./config-dev.yaml'));
-            args.push('--buildDrafts=true');
             args.push('--buildFuture=true');
         } else {
             args.push('--config=' + path.resolve('./config.yaml'));

--- a/config-dev.yaml
+++ b/config-dev.yaml
@@ -1,4 +1,4 @@
-baseurl: ""
+baseurl: "http://127.0.0.1:8081"
 title: "Vanilla Forums Documentation"
 builddrafts: false
 


### PR DESCRIPTION
Links being generated in local development were not correct. The `baseUrl` was getting set to nothing in the config file, and not being properly overridden by the command line flag. The `buildDrafts` flag was also being set in the `config-dev.yaml` so the extra flag being pushed into the args wasn't working properly. 

After this links generated on localhost are now the correct links.