### PR TITLE
Fix deprecation warning regarding the now variable

### DIFF
--- a/layouts/partials/footer/copyright.html
+++ b/layouts/partials/footer/copyright.html
@@ -1,3 +1,3 @@
 <div class="docs-copyright">
-    Copyright &copy 2009-{{ .Now.Year }} Vanilla Forums, Inc. All rights reserved.
+    Copyright &copy 2009-{{ now.Year }} Vanilla Forums, Inc. All rights reserved.
 </div>


### PR DESCRIPTION
Pages don’t have a Now property anymore, but there is a now template
function.