### PR TITLE
Replace arrows with unicode characters

### DIFF
--- a/content/developer/changelog/index.md
+++ b/content/developer/changelog/index.md
@@ -247,7 +247,7 @@ Changes:
 * Added ability to use IE targetting for CSS and JS files
 * Disabled CLEditor for IE6 users
 * Disabled popups in IE7 or less
-* Added Session support, see: Gdn_Session()→Stash()
+* Added Session support, see: Gdn_Session()->Stash()
 * Turns off Embed by default
 * Added WebOS to mobile user agents
 

--- a/content/developer/changelog/index.md
+++ b/content/developer/changelog/index.md
@@ -247,7 +247,7 @@ Changes:
 * Added ability to use IE targetting for CSS and JS files
 * Disabled CLEditor for IE6 users
 * Disabled popups in IE7 or less
-* Added Session support, see: Gdn_Session()->Stash()
+* Added Session support, see: Gdn_Session()→Stash()
 * Turns off Embed by default
 * Added WebOS to mobile user agents
 

--- a/content/help/addons/salesforce/index.md
+++ b/content/help/addons/salesforce/index.md
@@ -29,7 +29,7 @@ You must have SSL enabled on your domain. (Your forum must be served over HTTPS)
 
 1. Log into your Salesforce Account
 1. Create new Connected App in Salesforce
-  1. Build -> Create -> Apps -> Connected Apps -> New
+  1. Build → Create → Apps → Connected Apps → New
   1. Fill the required fields **Connected App Name**, **API Name**, **Contact Email**
   1. Enable OAuth Settings
   1. Set a Callback URL by appending `/profile/salesforceconnect` to the end of your forum's URL.

--- a/content/help/moderation/reporting/index.md
+++ b/content/help/moderation/reporting/index.md
@@ -18,7 +18,7 @@ Reporting is a way for members to bring moderators’ attention to content that 
 
 ## Reporting a post
 
-Go to Flag -> Report in the Reactions menu at the end of the post. A popup box will prompt you to add a “Reason” both to explain the report and discourage useless reports. Any member may use this function.
+Go to Flag → Report in the Reactions menu at the end of the post. A popup box will prompt you to add a “Reason” both to explain the report and discourage useless reports. Any member may use this function.
 
 Reporting content creates a new discussion in a special moderator-only forum.
 Additional reports of the same content (the exact same post) add new comments to the special discussion.

--- a/content/help/releases/2017.md
+++ b/content/help/releases/2017.md
@@ -79,9 +79,9 @@ _Q2 release 3 was skipped._
 ### Q2 release 2 (Wednesday, Apr 26)
 
 * Multiple menus in the Dashboard's Settings tab were renamed or reorganized.
-	* Banner -> Branding
-	* Homepage -> Layout
-	* Advanced -> Posting
+	* Banner → Branding
+	* Homepage → Layout
+	* Advanced → Posting
 	* Created "Security" menu group.
 	* Re-grouped several pages under different headings.
 * Tagging addon was removed. Its features are now a part of our core offering. No user-facing functionality was changed.

--- a/content/help/sso/saml/index.md
+++ b/content/help/sso/saml/index.md
@@ -16,7 +16,7 @@ aliases:
 ## SSO with SAML: Overview
 
 Vanilla has implemented the parts of the SAML 2.0 spec required for SSO. This is done by enabling the SAML SSO addon,
-and configuring it via its Settings page (Dashboard -> Addons -> SAML SSO -> Settings button).
+and configuring it via its Settings page (Dashboard → Addons → SAML SSO → Settings button).
 
 SAML accounts are mapped to existing forum accounts by **email address**, or a new account is created if no match is found.
 


### PR DESCRIPTION
I noticed that using “->” for some arrows looks quite ugly.