### PR TITLE
Add documentation about linting command

### DIFF
--- a/content/developer/addons/addon-info.md
+++ b/content/developer/addons/addon-info.md
@@ -259,6 +259,16 @@ A theme only property that tells Vanilla which views the theme users. Sometimes 
 },
 ```
 
+### Sites
+A list of Vanilla Forums Cloud sites to show display the addon on. See [Addon Visibility](/developer/addons/addon-visibility) for details.
+
+```json
+"sites": [
+    "mysite.vanillastaging.com",
+    "mysite.vanillacommunities.com
+],
+```
+
 ### build
 
 Specifies options for the [Vanilla CLI's build tool](/developer/vanilla-cli#build-tools).
@@ -279,12 +289,74 @@ Which CSS preprocessor to use. Current options are `scss` and `less`. The defaul
 }
 ```
 
-### Sites
-A list of Vanilla Forums Cloud sites to show display the addon on. See [Addon Visibility](/developer/addons/addon-visibility) for details.
+### lint
+
+Specifies options for the [Vanilla CLI's lint tool](/developer/vanilla-cli#linting-tools).
+
+#### lint.scripts
+
+##### lint.scripts.enable
+
+Enable linting of script files. Defaults to true.
+
+##### lint.scripts.configFile
+
+Provide a path to an ESLint config file. By default the following files will be checked:
+- `<addonDirectory>/.eslintrc`
+- `<addonDirectory>/.eslintrc.json`
+- `<addonDirectory>/.eslintrc.yaml`
+- `<addonDirectory>/config.eslintrc.js`
+
+#### lint.styles
+
+##### lint.scripts.enable
+
+Enable linting of SCSS stylesheets. Defaults to true.
+
+##### lint.scripts.configFile
+
+Provide a path to an StyleLint config file. By default the following files will be checked:
+- `<addonDirectory>/.stylelintrc`
+- `<addonDirectory>/.stylelintrc.json`
+- `<addonDirectory>/.stylelintrc.yaml`
+- `<addonDirectory>/config.stylelintrc.js`
+
+#### paths
+
+An array of files or globs to lint. Defaults to
+```json
+[
+    "src/**/*.js",
+    "src/**/*.jsx",
+    "src/**/*.scss"
+]
+```
+
+#### Example
 
 ```json
-"sites": [
-    "mysite.vanillastaging.com",
-    "mysite.vanillacommunities.com
-],
+"lint": {
+    "scripts": {
+        "configFile": "otherDirectory/.eslintrc"
+    },
+    "styles": {
+        "enable": false,
+    },
+    "paths": [
+        "otherDirectory/src/**/.js",
+        "otherDirectory/src/**/.jsx"
+    ]
+}
+```
+
+#### build.cssTool
+
+Which CSS preprocessor to use. Current options are `scss` and `less`. The default is `scss`.
+
+#### Example 
+```json
+"build": {
+    "processVersion": "v1",
+    "cssTool": "scss"
+}
 ```

--- a/content/developer/addons/addon-info.md
+++ b/content/developer/addons/addon-info.md
@@ -302,6 +302,7 @@ Enable linting of script files. Defaults to true.
 ##### lint.scripts.configFile
 
 Provide a path to an ESLint config file. By default the following files will be checked:
+
 - `<addonDirectory>/.eslintrc`
 - `<addonDirectory>/.eslintrc.json`
 - `<addonDirectory>/.eslintrc.yaml`
@@ -316,6 +317,7 @@ Enable linting of SCSS stylesheets. Defaults to true.
 ##### lint.scripts.configFile
 
 Provide a path to an StyleLint config file. By default the following files will be checked:
+
 - `<addonDirectory>/.stylelintrc`
 - `<addonDirectory>/.stylelintrc.json`
 - `<addonDirectory>/.stylelintrc.yaml`

--- a/content/developer/vanilla-cli/index.md
+++ b/content/developer/vanilla-cli/index.md
@@ -66,7 +66,7 @@ This tool has its own javascript dependencies that it relies on to function prop
 
 ## Linting Tools
 
-The Vanilla CLI bundles a linter that enforces Vanilla Forums standards of code quality for SCSS stylesheets and javscripts files. It is built using [ESLint](https://eslint.org/) and [StyleLint](https://stylelint.io/).
+The Vanilla CLI bundles a linter that enforces Vanilla Forums standards of code quality for SCSS stylesheets and javscripts files. It is built using [ESLint](https://eslint.org/) and [StyleLint](https://stylelint.io/). Options are determined with fallbacks in this order CLI Options/Args > Configuration > Defaults. Configuration can be specific in the [addon.json file](/developer/addons/addon-info#lint).
 
 ### Usage
 `vanilla build [<options>] [<arguments>]`

--- a/content/developer/vanilla-cli/index.md
+++ b/content/developer/vanilla-cli/index.md
@@ -64,6 +64,35 @@ Log additional output to stdout. This is helpful for finding out what might be w
 #### `--reset`
 This tool has its own javascript dependencies that it relies on to function properly. Some of these are native modules and may require recompilation if your OS or Node.js installation get upgraded. This flags clears all cached modules and reinstall/recompiles them. The tool will attempt to do this automatically if necessary, but this command can be useful for fixing dependency related issues.
 
+## Linting Tools
+
+The Vanilla CLI bundles a linter that enforces Vanilla Forums standards of code quality for SCSS stylesheets and javscripts files. It is built using [ESLint](https://eslint.org/) and [StyleLint](https://stylelint.io/).
+
+### Usage
+`vanilla build [<options>] [<arguments>]`
+
+### Options
+
+#### `--scripts`
+
+Causes the tool to only run the javascript related parts of the process.
+
+#### `--scripts`
+
+Causes the tool to only run the javascript related parts of the process.
+
+#### `--watch`
+
+Run to the tool in watch mode. Changed files will be linted. Currently newly added files require a re-running the command.
+
+#### `--fix`
+
+Lint the files and attempt to automatically fix certain types of linting errors.
+
+### Arguments
+
+Arguments should be file paths or globs to be linted. The default arguments are `src/**/*.js src/**/*.jsx src/**/*.scss`. `node_modules` and `vendor` directories will be ignored automatically. This allows arbitrary files to be linted.
+
 ## Addon Utilities
 
 The Vanilla CLI offers a few utilities to make managing your addons easier. They only work with addons currently installed in a Vanilla installation and function by using Vanilla's built in addon manager to do the heavy lifting. As a result, these commands require you to point them to the vanilla directory with the `--vanillasrc` parameter.

--- a/content/developer/vanilla-cli/index.md
+++ b/content/developer/vanilla-cli/index.md
@@ -91,7 +91,9 @@ Lint the files and attempt to automatically fix certain types of linting errors.
 
 ### Arguments
 
-Arguments should be file paths or globs to be linted. The default arguments are `src/**/*.js src/**/*.jsx src/**/*.scss`. `node_modules` and `vendor` directories will be ignored automatically. This allows arbitrary files to be linted.
+Arguments should be file paths or globs to be linted. The default arguments are `"src/**/*.js" "src/**/*.jsx" "src/**/*.scss"`. `node_modules` and `vendor` directories will be ignored automatically. This allows arbitrary files to be linted.
+
+Be sure to put quotes around glob arguments. If there are no quotes a glob bash/zsh/fish may automatically expand the glob, which will prevent files from being ignored properly.
 
 ## Addon Utilities
 


### PR DESCRIPTION
Adds documentation about the `vanilla lint` command in the CLI and its addon.json configuration options.

On hold until the functionality is merged into the CLI.