### PR TITLE
Fix doubled search results

### DIFF
--- a/static/js/search.js
+++ b/static/js/search.js
@@ -1,5 +1,5 @@
 $(function($){
-    
+
     var cache = {
         set: function (key, val, exp) {
             cache.store.set(key, {
@@ -60,13 +60,13 @@ $(function($){
     }
 
     var $results = $('.js-search-results'),
-        $template = $results.find('.searchResult');
+        $template = $results.find('.searchResult').first();
 
     var searchHandler = function (e) {
         var $input = $(e.currentTarget),
             matches = [],
             query = escapeHTML($input.val());
-    
+
         if (query.length < 3) {
             $results.removeClass('open');
             return;


### PR DESCRIPTION
The doubled search results were bothering me so I did a quick look and it seems we were cloning an existing search result element with jquery, but since we made the page responsive it would be cloned twice. I've fixed the issue by grabbing the first `searchResult` instead of all of them as a template.