### PR TITLE
Fixed Badge give user API Call

### DIFF
--- a/content/api/badges/index.md
+++ b/content/api/badges/index.md
@@ -123,7 +123,7 @@ All fields are optional except Badge. Updates are sparse, so supply only the fie
 ## /badges/give
 
 ```http
-POST /api/v1/badges/give.ext HTTP/1.1
+POST /api/v1/badges/giveuser.ext HTTP/1.1
 HOST: https://yoursite.vanillaforums.com
 ```
 


### PR DESCRIPTION
Giving a badge using the API would need to call  /api/v1/badges/giveuser.json instead of  /api/v1/badges/give.json