### PR TITLE
Add core build process info and installation guide

### DIFF
--- a/content/developer/addons/addon-info.md
+++ b/content/developer/addons/addon-info.md
@@ -302,13 +302,13 @@ This parameter has been renamed before. In previous versions of the `vanilla-cli
 
 #### build.entries
 
-Entries are available only in the [core build process](/developer/vanilla-cli/build-process-core/#runnable-bundles).
+Entries are available only in the [core build process](/developer/vanilla-cli/build-process-core/#executable-bundles).
 
 The `entries` of desired output files to entry files. It is an object mapping `string => string`, where the key is used to resolve the output filename and location, and the value is used to resolve the location of the entrypoint. Most addons should have very few entries and many will have just 1.
 
 #### build.exports
 
-Exports are available only in the [core build process](/developer/vanilla-cli/build-process-core/#library-bundles).
+Exports are available only in the [core build process](/developer/vanilla-cli/build-process-core/#dependency-bundles).
 
 They are used to allow allow addons to build against other addons. Anything resolved in an export gets outputted into a separate library for other addons to build against.
 

--- a/content/developer/addons/addon-info.md
+++ b/content/developer/addons/addon-info.md
@@ -275,23 +275,69 @@ A list of Vanilla Forums Cloud sites to show display the addon on. See [Addon Vi
 ],
 ```
 
+### parent
+
+The [core build process](/developer/vanilla-cli/build-process-core#child-themes) allows themes to build against each other in order to facilitate stylesheet re-use. This key should be the addon `key` of another theme build with the `core` build process.
+
+#### Example
+```json
+{
+    "key": "child-theme",
+    "parent": "parent-theme",
+    "build": {
+        "process": "core"
+    }
+}
+```
+
 ### build
 
 Specifies options for the [Vanilla CLI's build tool](/developer/vanilla-cli#build-tools).
 
-#### build.processVersion
+#### build.process
 
-Which process version to use. Currently available processes are [v1](/developer/vanilla-cli/build-process-v1) and [legacy](/developer/vanilla-cli/build-process-legacy). The default is `legacy` for backwards compatibility purposes.
+Which process version to use. Currently available processes are [core](/developer/vanilla-cli/build-process-core), [v1](/developer/vanilla-cli/build-process-v1) and [legacy](/developer/vanilla-cli/build-process-legacy). The default is `legacy` for backwards compatibility purposes.
+
+This parameter has been renamed before. In previous versions of the `vanilla-cli`, this key was called `buildProcessVersion` and `build.processVersion`. These keys are deprecated but will continue to work. The tool internally maps them to the new key.
+
+#### build.entries
+
+Entries are available only in the [core build process](/developer/vanilla-cli/build-process-core/#runnable-bundles).
+
+The `entries` of desired output files to entry files. It is an object mapping `string => string`, where the key is used to resolve the output filename and location, and the value is used to resolve the location of the entrypoint. Most addons should have very few entries and many will have just 1.
+
+#### build.exports
+
+Exports are available only in the [core build process](/developer/vanilla-cli/build-process-core/#library-bundles).
+
+They are used to allow allow addons to build against other addons. Anything resolved in an export gets outputted into a separate library for other addons to build against.
 
 #### build.cssTool
 
 Which CSS preprocessor to use. Current options are `scss` and `less`. The default is `scss`.
 
-#### Example 
+#### Build Example 
 ```json
 "build": {
-    "processVersion": "v1",
-    "cssTool": "scss"
+    "process": "v1",
+    "cssTool": "scss",
+    "entries": {
+        "output.js": "./entry.js"
+    }
+}
+```
+```json
+"build": {
+    "key": "dashboard",
+    "process": "core",
+    "entries": {
+        "app": "./app/index.js",
+        "admin": "./admin/index.js"
+    },
+    "exports": {
+        "app": ["./common/Modal", "./app/ProfileEvents", "moment"],
+        "admin": ["./common/Modal", "./admin/jenga-blocks", "ace", "moment", "bootstrap", "jquery"]
+    }
 }
 ```
 
@@ -354,17 +400,5 @@ An array of files or globs to lint. Defaults to
         "otherDirectory/src/**/.js",
         "otherDirectory/src/**/.jsx"
     ]
-}
-```
-
-#### build.cssTool
-
-Which CSS preprocessor to use. Current options are `scss` and `less`. The default is `scss`.
-
-#### Example 
-```json
-"build": {
-    "processVersion": "v1",
-    "cssTool": "scss"
 }
 ```

--- a/content/developer/vanilla-cli/build-process-core.md
+++ b/content/developer/vanilla-cli/build-process-core.md
@@ -9,6 +9,7 @@ tags:
 - parent
 - child
 - library
+- dependency
 
 category: developer
 menu:
@@ -18,13 +19,13 @@ versioning:
   added: 2.6
 ---
 
-This is the primary Vanilla Forums build process. It is used to build assets for vanilla's core, and it's addons. It is build using [Webpack](https://webpack.js.org/), [node-sass](https://github.com/sass/node-sass) and [babel](https://babeljs.io/). The `core` process can generate multiple javascript bundles and multiple built stylesheets for an addon. Its primary differences from the v1 process is that it enables building against other addons. Code can be shared between addons by using [library bundles](#library-bundles) and [child themes](#child-themes).
+This is the primary Vanilla Forums build process. It is used to build assets for vanilla's core, and it's addons. It is build using [Webpack](https://webpack.js.org/), [node-sass](https://github.com/sass/node-sass) and [babel](https://babeljs.io/). The `core` process can generate multiple javascript bundles and multiple built stylesheets for an addon. Its primary differences from the v1 process is that it enables building against other addons. Code can be shared between addons by using [dependency bundles](#dependency-bundles) and [child themes](#child-themes).
 
 ## Contents
 
 - [Folder Structure](#folder-structure)
-- [Library Bundles](#library-bundles)
-- [Runnable Bundles](#runnable-bundles)
+- [Dependency Bundles](#dependency-bundles)
+- [Executable Bundles](#executable-bundles)
 - [App & Admin Bundles](#app-admin-bundles)
 - [Stylesheets](#stylesheets)
 - [Child Themes](#child-themes)
@@ -37,10 +38,10 @@ Javascript source files are located in the `src/js` directory and built into the
 
 Javascript entry points must be explicitly defined in the [addon.json file](/developer/addons/addon-info#build). Stylesheet entry points are inferred. Any file matching the pattern `src/scss/**/*.scss` that does not match `_*.scss` will be used as an entry point.
 
-## Library Bundles
-Library bundles are built from the files defined in `build.exports` of the [addon.json file](/developer/addons/addon-info/#build-exports).
+## Dependency Bundles
+Dependency bundles are built from the files defined in `build.exports` of the [addon.json file](/developer/addons/addon-info/#build-exports).
 
-Library Bundles are used to separate out common chunks of code from between addons. Each export will generate a `lib-<ADDON_KEY>-<EXPORT_KEY>.js` bundle in the `js` folder of the addon and a `*-manifest.json` file in the `manifests` folder of the addon. The manifest file is a mapping for other bundles to build against so be sure to check those into version control. So an `exports` object like the following
+Dependency Bundles are used to separate out common chunks of code from between addons. Each export will generate a `lib-<ADDON_KEY>-<EXPORT_KEY>.js` bundle in the `js` folder of the addon and a `*-manifest.json` file in the `manifests` folder of the addon. The manifest file is a mapping for other bundles to build against so be sure to check those into version control. So an `exports` object like the following
 
 ```json
 "build": {
@@ -55,22 +56,22 @@ Library Bundles are used to separate out common chunks of code from between addo
 
 would generate bundles `js/lib-dashboard-app.js` and `js/lib-dashboard-admin.js` and manifests `manifests/app-manifest.json` and `manifests/admin-manifest.json`
 
-### What should go into a library bundle?
+### What should go into a dependency bundle?
 
 - Modular code that you want to consume from your own addon and/or other addons.
 - Vendor Libraries.
 - React Components.
 
-### What not to include in a library bundle?
+### What not to include in a dependency bundle?
 
-- Code that needs to be run by including a script in the page. If you want to put code for your own addon in a library bundle, be sure to import it properly in a [runnable bundle](#runnable-bundles).
+- Code that needs to be run by including a script in the page. If you want to put code for your own addon in a dependency bundle, be sure to import it properly in a [executable bundle](#executable-bundles).
 - Large files that are only meant to be included on a single page. These should be included in a separate bundle, or used as a global for that page.
 
-## Consuming a library bundle
+## Consuming a dependency bundle
 
-Library bundles can be consumed through other library bundles or through a [runnable bundle](#runnable-bundles). Any time that you build a bundle it will check the requirements declared in the `require` [addon.json key](/developer/addons/addon-info/#require) and build against the libraries from that addon. In addition to the requirements explicity declared in the `require` key, all addons build against their own library bundles and the core library bundles.
+Dependency bundles can be consumed through other dependency bundles or through a [executable bundle](#executable-bundles). Any time that you build a bundle it will check the requirements declared in the `require` [addon.json key](/developer/addons/addon-info/#require) and build against the libraries from that addon. In addition to the requirements explicity declared in the `require` key, all addons build against their own dependency bundles and the core dependency bundles.
 
-If a file declared in a required library bundle is imported, then that import will automatically be replaced with a reference to the library bundle in the outputed file. This is only possible if the imported file path resolves to the same location as the `build.exports` declaration in the required addon.
+If a file declared in a required dependency bundle is imported, then that import will automatically be replaced with a reference to the dependency bundle in the outputed file. This is only possible if the imported file path resolves to the same location as the `build.exports` declaration in the required addon.
 
 Some aliases have been provided to make importing slightly easier.
 
@@ -100,9 +101,9 @@ The `core` build process will automatically attempt to resolve node_modules in t
 
 No special syntax is required. If the modules you are trying to import is not explicitly an export from core, dashboard, vanilla, or your own addon will not be de-duplicated, so watch your bundle sizes!
 
-## Runnable Bundles
+## Executable Bundles
 
-Runnable bundles are built from the `build.entries` of the [addon.json file](/developer/addons/addon-info/#build-entries). Each entry point will generate an `<ADDON_KEY>-<ENTRY_KEY>.js` bundle in the `js` folder of the addon. So an `entries` object like the following
+Executable bundles are built from the `build.entries` of the [addon.json file](/developer/addons/addon-info/#build-entries). Each entry point will generate an `<ADDON_KEY>-<ENTRY_KEY>.js` bundle in the `js` folder of the addon. So an `entries` object like the following
 
 ```json
 "build": {
@@ -117,7 +118,7 @@ Runnable bundles are built from the `build.entries` of the [addon.json file](/de
 
 would generate bundles `js/dashboard-app.js` and `js/dashboard-admin.js` from the entrypoints `src/js/app/index.js` and `src/js/admin/index.js`.
 
-A runnable bundle is the actual exectuable javascript for your addon. This is place for 
+An executable bundle is the actual runnable javascript for your addon. This is the place for 
 
 - Registering event listeners and hooks.
 - Modifying the DOM.
@@ -151,7 +152,7 @@ This build process works with the [Sass preprocessor](http://sass-lang.com/). Th
 
 ### Child Themes
 
-The `core` build process allows themes to build against each other by specifying the [parent key in the addon.json file](/developer/addons/addon-info/#parent). For the build to work both themes must define be using the `core` build process. This enables the parent theme to specify some special entry points in it's stylesheets for the child theme to hook into.
+The `core` build process allows themes to build against each other by specifying the [parent key in the addon.json file](/developer/addons/addon-info/#parent). For the build to work both themes must define be using the `core` build process. This enables the parent theme to specify some special entry points in it's stylesheets for the child theme to hook into. ***Note: while multiple levels of children may technically build (eg. grandchildren) this setup is heavily discouraged.***
 
 #### Defining a Parent Theme
 

--- a/content/developer/vanilla-cli/build-process-core.md
+++ b/content/developer/vanilla-cli/build-process-core.md
@@ -1,0 +1,195 @@
+---
+title: Build Process - Core
+tags:
+- Developers
+- CLI
+- Build Tools
+- Process
+- core
+- parent
+- child
+- library
+
+category: developer
+menu:
+  developer:
+    parent: cli
+versioning:
+  added: 2.6
+---
+
+This is the primary Vanilla Forums build process. It is used to build assets for vanilla's core, and it's addons. It is build using [Webpack](https://webpack.js.org/), [node-sass](https://github.com/sass/node-sass) and [babel](https://babeljs.io/). The `core` process can generate multiple javascript bundles and multiple built stylesheets for an addon. Its primary differences from the v1 process is that it enables building against other addons. Code can be shared between addons by using [library bundles](#library-bundles) and [child themes](#child-themes).
+
+## Contents
+
+- [Folder Structure](#folder-structure)
+- [Library Bundles](#library-bundles)
+- [Runnable Bundles](#runnable-bundles)
+- [App & Admin Bundles](#app-admin-bundles)
+- [Stylesheets](#stylesheets)
+- [Child Themes](#child-themes)
+
+## Folder Structure
+
+Source files are always found in one of two places - the `src` directory or the `node_modules` directory. Node modules can be installed from [npm](https://www.npmjs.com/) with [yarn](https://yarnpkg.com/en/).
+
+Javascript source files are located in the `src/js` directory and built into the `js` directory of the addon. Stylesheet source files (Sass) are located in the `src/scss` directory and are built into the `design` directory of the addon.
+
+Javascript entry points must be explicitly defined in the [addon.json file](/developer/addons/addon-info#build). Stylesheet entry points are inferred. Any file matching the pattern `src/scss/**/*.scss` that does not match `_*.scss` will be used as an entry point.
+
+## Library Bundles
+Library bundles are built from the files defined in `build.exports` of the [addon.json file](/developer/addons/addon-info/#build-exports).
+
+Library Bundles are used to separate out common chunks of code from between addons. Each export will generate a `lib-<ADDON_KEY>-<EXPORT_KEY>.js` bundle in the `js` folder of the addon and a `*-manifest.json` file in the `manifests` folder of the addon. The manifest file is a mapping for other bundles to build against so be sure to check those into version control. So an `exports` object like the following
+
+```json
+"build": {
+    "key": "dashboard",
+    "process": "core",
+    "exports": {
+        "app": ["./common/Modal", "./app/ProfileEvents", "moment"],
+        "admin": ["./common/Modal", "./admin/jenga-blocks", "ace", "moment", "bootstrap", "jquery"]
+    }
+}
+```
+
+would generate bundles `js/lib-dashboard-app.js` and `js/lib-dashboard-admin.js` and manifests `manifests/app-manifest.json` and `manifests/admin-manifest.json`
+
+### What should go into a library bundle?
+
+- Modular code that you want to consume from your own addon and/or other addons.
+- Vendor Libraries.
+- React Components.
+
+### What not to include in a library bundle?
+
+- Code that needs to be run by including a script in the page. If you want to put code for your own addon in a library bundle, be sure to import it properly in a [runnable bundle](#runnable-bundles).
+- Large files that are only meant to be included on a single page. These should be included in a separate bundle, or used as a global for that page.
+
+## Consuming a library bundle
+
+Library bundles can be consumed through other library bundles or through a [runnable bundle](#runnable-bundles). Any time that you build a bundle it will check the requirements declared in the `require` [addon.json key](/developer/addons/addon-info/#require) and build against the libraries from that addon. In addition to the requirements explicity declared in the `require` key, all addons build against their own library bundles and the core library bundles.
+
+If a file declared in a required library bundle is imported, then that import will automatically be replaced with a reference to the library bundle in the outputed file. This is only possible if the imported file path resolves to the same location as the `build.exports` declaration in the required addon.
+
+Some aliases have been provided to make importing slightly easier.
+
+- `@core` => `<VANILLA_SRC_DIRECTORY>/core/src/js` 
+- `@vanilla` => `<VANILLA_SRC_DIRECTORY>/applications/vanilla/src/js`
+- `@dashboard` => `<VANILLA_SRC_DIRECTORY>/applications/dashboard/src/js`
+- Required addons will also have aliases generated for them. For example if the `vanilla-editor` addon was required, the following mapping would be generated.      
+    - `@vanilla-editor` => `<VANILLA_SRC_DIRECTORY>/plugins/editor/src/js`.
+
+```js
+import * as React from "react";
+import { Modal } from "@dashboard/app/components";
+import Editor from "@vanilla-editor/editor";
+import Events from "@core/events";
+```
+
+You should very rarely need to build off of an addon other than `core`, `dashboard`, or `vanilla`.
+
+### node_modules
+
+The `core` build process will automatically attempt to resolve node_modules in the following order:
+
+1. `core/node_modules` 
+1. `applications/dashboard/node_modules` 
+1. `applications/vanilla/node_modules` 
+1. `YOUR_ADDON/node_modules`.
+
+No special syntax is required. If the modules you are trying to import is not explicitly an export from core, dashboard, vanilla, or your own addon will not be de-duplicated, so watch your bundle sizes!
+
+## Runnable Bundles
+
+Runnable bundles are built from the `build.entries` of the [addon.json file](/developer/addons/addon-info/#build-entries). Each entry point will generate an `<ADDON_KEY>-<ENTRY_KEY>.js` bundle in the `js` folder of the addon. So an `entries` object like the following
+
+```json
+"build": {
+    "key": "dashboard",
+    "process": "core",
+    "entries": {
+        "app": "./app/index.js",
+        "admin": "./admin/index.js"
+    }
+}
+```
+
+would generate bundles `js/dashboard-app.js` and `js/dashboard-admin.js` from the entrypoints `src/js/app/index.js` and `src/js/admin/index.js`.
+
+A runnable bundle is the actual exectuable javascript for your addon. This is place for 
+
+- Registering event listeners and hooks.
+- Modifying the DOM.
+- Mounting React components.
+- Consuming library components.
+
+## App & Admin Bundles
+
+Addons should attempt to build as few separate bundles as possible. Many addons can get away with having a single entry points, but App & Admin sections are a common separation point. These are not strictly defined by the the build tool but the convention is to have any entries/exports key with multiple keys (`admin`, `app`). See [the addon.json build key example](/developer/addons/addon-info#build-example).
+
+### App
+
+The App section of Vanilla is the front-end/client/consumer facing portion of Vanilla. This is the part of Vanilla that is viewed by an average user. Currently this includes CategoryLists, DiscussionLists, Discussions, Profiles, ConversationLists, Conversations, and more.
+
+This is ***not***:
+
+- Everything the in Vanilla application.
+- Front-end as in front-end/back-end web development.
+
+### Admin
+
+The Admin section of Vanilla is what is traditionally thought of as the "Dashboard". It is made up of all the configuration screens / admin panel / etc. This is accessible to much fewer users. This should not be confused with the `dashboard` addon, which provides both an Admin section (the control panel, settings, etc), and an app section (The profile pages).
+
+## Stylesheets
+
+Stylesheets are built with SCSS. Source files should be placed in the `src/scss` directory. Any file ending in `*.scss` that does not begin with an underscore `_` is considered a source file. Filenames beginning with an underscore such as `_partial.scss` signify a partial. These do not get built on their own and must use the `@import` directive to include them. See [The Sass language guide](http://sass-lang.com/guide) for more details.
+
+Each entry stylesheet will be run through their preprocessor and be outputed into the `design` folder with the filename `<entryname>.css`. So for an outputted file to be `design/myfile.css`, its source file would need to be located at `src/scss/myfile.scss`.
+
+This build process works with the [Sass preprocessor](http://sass-lang.com/). This build tool uses a custom importer function simplifiy importing node_modules scss dependencies. See [the bundling process](/developer/vanilla-cli/bundling-process/#sass) for more details on importing sass files.
+
+### Child Themes
+
+The `core` build process allows themes to build against each other by specifying the [parent key in the addon.json file](/developer/addons/addon-info/#parent). For the build to work both themes must define be using the `core` build process. This enables the parent theme to specify some special entry points in it's stylesheets for the child theme to hook into.
+
+#### Defining a Parent Theme
+
+Any theme can be a parent theme. Parent themes can, but don't necessarily have to define special entrypoints for it's children. They go in a scss file and look like this:
+
+**themes/parent-theme/src/scss/custom.scss**
+```scss
+/** @vanilla-cli-placeholder: _variables.scss **/
+
+// Parent theme styles here
+$color: red !default;
+
+.selector {
+    color: $color
+}
+
+/** @vanilla-cli-placeholder: _custom.scss **/
+```
+
+When building the parent theme directory these placeholders will just be ignored because they are comments. The file name specified after `@vanilla-cli-placeholder:` will be used to lookup a child files to get dynamically inserted while building a child theme.
+
+#### Building a Child Theme
+
+The only strict requirement for a theme to be a child theme are:
+
+- Specifying a `parent` key in the addon.json file.
+- Both the parent theme and child theme use the `core` build process.
+- Both the parent theme and the child theme must be symlinked into the same vanilla source directory.
+
+By default running `vanilla build` in a child theme will lookup the parent theme, and build the parent's stylesheets in `themes/parent-theme/src/scss` into `themes/child-theme/design`. The magic happens with `@vanilla-cli-placeholder` annotations in the parent theme. The child theme can define files to replace those placeholders.
+
+For example. If the parent theme defines the `custom.scss` file above it has two placeholders files.
+
+- `_variables.scss`
+- `_custom.scss`
+
+If you create these two files in `themes/child-theme/src/scss` their contents will be inserted in place of the respective `@vanilla-cli-placeholder` annotations.
+
+## Bundling Process
+
+See the [Bundling Process](/developer/vanilla-cli/bundling-process) page for details about the CLI bundles it's assets and the transforms that can be applied to javascript through the build process.

--- a/content/developer/vanilla-cli/build-process-v1.md
+++ b/content/developer/vanilla-cli/build-process-v1.md
@@ -14,7 +14,7 @@ versioning:
   added: 2.5
 ---
 
-This is the primary build process. It is based on the build tool [gulp](http://gulpjs.com/). It builds stylesheets using [node-sass](https://github.com/sass/node-sass) or [less](https://github.com/less/less.js/tree/master) and bundles javascript with [Webpack](https://github.com/webpack/webpack) and [babel](https://babeljs.io/).
+This is one of the built-in build processes. It is based on the task runner [gulp](http://gulpjs.com/). It builds stylesheets using [node-sass](https://github.com/sass/node-sass) or [less](https://github.com/less/less.js/tree/master) and bundles javascript with [Webpack](https://github.com/webpack/webpack) and [babel](https://babeljs.io/).
 
 This build process was formerly called `1.0`. It has now been renamed to `v1`. Existing addon.json files referencing the process version `1.0` will continue to work.
 
@@ -38,7 +38,7 @@ Source files should be placed in the `src/less` directory. Any file ending in `*
 
 ### Javascript
 
-The javascript entry point is currently always found at `src/js/index.js`. This tool does not currently support multiple javascript entry files.
+The javascript entry point is currently always found at `src/js/index.js` and will generate a bundle at `js/custom.js`. This tool does not currently support multiple javascript entry  files or custom entrypoints/outputs. For custom entrypoints see the [core build process](/developer/vanilla-cli/build-process-core).
 
 ### Images
 

--- a/content/developer/vanilla-cli/index.md
+++ b/content/developer/vanilla-cli/index.md
@@ -29,13 +29,14 @@ Current functionalities include:
 
 ## Getting Started
 
-Follow the [setup guide](https://github.com/vanilla/vanilla-cli#setup) in the `vanilla-cli` repo.
+Follow the [setup guide](/developer/vanilla-cli/installation).
 
 ## Build Tools
 
 The Vanilla CLI bundles it's own build tool to make starting and mainting your Vanilla Forums addons easier.
 
 - [Build Tool Quickstart Guide](/developer/vanilla-cli/build-quickstart)
+- [Build Process - Core](/developer/vanilla-cli/build-process-core)
 - [Build Process - 1.0](/developer/vanilla-cli/build-process-v1)
 - [Build Process - Legacy](/developer/vanilla-cli/build-process-legacy)
 - [How Bundling Works](/developer/vanilla-cli/bundling-process)
@@ -50,7 +51,7 @@ The Vanilla Build Tool aims to provide a consistant experience to building front
 ### Options
 
 #### `--process [process_version]`
-Select the build process you wish to use. This will override any other method of settings such the `build.processVersion` in the [addon.json](/developer/addons/addon-info/#build). Current options are [v1](/developer/vanilla-cli/build-process-v1) and [legacy](/developer/vanilla-cli/build-process-legacy).
+Select the build process you wish to use. This will override any other method of settings such the `build.processVersion` in the [addon.json](/developer/addons/addon-info/#build). Current options are [core](/developer/vanilla-cli/build-process-v1), [v1](/developer/vanilla-cli/build-process-v1) and [legacy](/developer/vanilla-cli/build-process-legacy).
 
 #### `--csstool [tool_name]`
 Select the CSS preprocessor to use. Current options are `scss` and `less`. The default is `scss`.

--- a/content/developer/vanilla-cli/installation.md
+++ b/content/developer/vanilla-cli/installation.md
@@ -1,0 +1,60 @@
+---
+title: Installation
+tags:
+- Developers
+- CLI
+- Build
+- Javascript
+- Import
+- Bundle
+- Webpack
+- ES Module
+category: developer
+menu:
+  developer:
+    parent: cli
+---
+
+## Prerequisites
+The CLI requires PHP `5.6.0` or greater installed to run. It also requires [composer](https://getcomposer.org/).
+
+Some commands, currently `build` and `lint`, require a minimum Node.js version of `8.3.0` and the package manager `yarn` to be installed. Installation instructions are located [in the wik](https://github.com/vanilla/vanilla-cli/wiki/Node.js-Processes).
+
+### Installing Node
+
+#### For OS X
+```bash
+brew install node
+brew install yarn
+```
+
+#### For Debian/Ubuntu Linux
+```bash
+curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash -
+curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
+echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
+
+sudo apt-get update && sudo apt-get install nodejs yarn
+```
+
+## Setup
+
+### Installation with Composer
+
+1. Run `composer global require 'vanilla/vanilla-cli'`.
+2. If your composer bin directory is on your path, you can now run the tool with `vanilla`. If you are having difficulty locating your composer bin directory it is likely located at `~/.composer/vendor/bin`
+
+### Manual Installation
+
+1. Clone this repo to the installation directory 
+```bash
+cd INSTALLATION_FOLDER
+git clone git@github.com:vanilla/vanilla-cli.git
+```
+2. Install the PHP dependancies in the directory where you clone this project.
+```bash
+cd vanilla-cli
+composer install
+```
+3. Run the tool `./bin/vanilla --help`
+4. (Optional) Symlink the tool somewhere on your path. `ln -s ./bin/vanilla SOME_BIN_DIRECTORY`

--- a/content/developer/vanilla-cli/installation.md
+++ b/content/developer/vanilla-cli/installation.md
@@ -18,7 +18,7 @@ menu:
 ## Prerequisites
 The CLI requires PHP `5.6.0` or greater installed to run. It also requires [composer](https://getcomposer.org/).
 
-Some commands, currently `build` and `lint`, require a minimum Node.js version of `8.3.0` and the package manager `yarn` to be installed. Installation instructions are located [in the wik](https://github.com/vanilla/vanilla-cli/wiki/Node.js-Processes).
+Some commands, currently `build` and `lint`, require a minimum Node.js version of `8.3.0` and the package manager `yarn` to be installed.
 
 ### Installing Node
 


### PR DESCRIPTION
Closes #177, #176, #162 

This PR adds documentation about the core build process, including it's new methods of bundling, and child theme support.

I've also added an installation guide for the build tool.