### PR TITLE
Add alias for broken Github docs link in internal repo

### DIFF
--- a/content/help/addons/social/github/index.md
+++ b/content/help/addons/social/github/index.md
@@ -10,6 +10,8 @@ menu:
     parent: addons-social
     identifier: addons-social-github
     weight: 2
+aliases:
+- help/integrations/github
 ---
 
 ## Github

--- a/content/help/addons/social/github/index.md
+++ b/content/help/addons/social/github/index.md
@@ -11,7 +11,7 @@ menu:
     identifier: addons-social-github
     weight: 2
 aliases:
-- help/integrations/github
+- /help/integrations/github
 ---
 
 ## Github


### PR DESCRIPTION
Move the addon social integration with the other addons