### PR TITLE
Fix broken advanced editor link

### DIFF
--- a/content/help/addons/advanced-editor/index.md
+++ b/content/help/addons/advanced-editor/index.md
@@ -101,7 +101,7 @@ If you are an administrator, you can change the settings for the editor in the D
 
 ![Advanced Editor Dashboard Settings](https://images.v-cdn.net/docs/AE_DashboardSettings.PNG)
 
-A quick breakdown of these additional settings can be found, [here](https://docs.vanillaforums.com/help/addons/advanced-editor/additional-settings/).
+A quick breakdown of these additional settings can be found, [here](/help/addons/advanced-editor/additional-settings/).
 
 ## Additional Resources
 

--- a/content/help/addons/advanced-editor/index.md
+++ b/content/help/addons/advanced-editor/index.md
@@ -101,7 +101,7 @@ If you are an administrator, you can change the settings for the editor in the D
 
 ![Advanced Editor Dashboard Settings](https://images.v-cdn.net/docs/AE_DashboardSettings.PNG)
 
-A quick breakdown of these additional settings can be found, [here](http://docs.vanillaforums.com/help/posting/additional-settings/).
+A quick breakdown of these additional settings can be found, [here](https://docs.vanillaforums.com/help/addons/advanced-editor/additional-settings/).
 
 ## Additional Resources
 


### PR DESCRIPTION
Fix link to Advanced settings of Advanced Editor (original link leads to a 404 page).