### PR TITLE
Add back themehooks docs with additional examples

### DIFF
--- a/content/developer/addons/events-and-handlers.md
+++ b/content/developer/addons/events-and-handlers.md
@@ -9,6 +9,10 @@ tags:
 - EventArguments
 - magic
 - create
+- Gdn_Form
+- Settings Page
+- Custom
+- ConfigurationModule
 category: addons
 menu:
   developer:
@@ -163,7 +167,20 @@ public function base_render_before($sender) {
 
 ### Create an additional settings page
 
-This example creates a custom dashboard page that can set a few configuration options. You would then need to use these set configuration values in other hooks to customize your site. The configuration module uses Gdn_Form internally and renders an nice looking form for the dashboard. Its implementation can be found [here](https://github.com/vanilla/vanilla/blob/master/applications/dashboard/views/modules/configuration.php). Further details can be found by looking through [Gdn_Form](https://github.com/vanilla/vanilla/blob/master/library/core/class.form.php). Not all form values are supported, but additional and more complex examples of it's use can be found in the  `SettingsController` and Vanilla's bundled plugins.
+This example creates a custom dashboard page that can set a few configuration options. You would then need to use these set configuration values in other hooks to customize your site. The configuration module uses Gdn_Form internally and renders an nice looking form for the dashboard. Its implementation can be found [here](https://github.com/vanilla/vanilla/blob/master/applications/dashboard/views/modules/configuration.php). Further details can be found by looking through [Gdn_Form](https://github.com/vanilla/vanilla/blob/master/library/core/class.form.php). Not all form values are supported. Currently supported form values are 
+
+- `categorydropdown`
+- `labelcheckbox`
+- `checkbox`
+- `toggle`
+- `dropdown`
+- `imageupload`
+- `color`
+- `radiolist`
+- `checkboxlist`
+- `textbox`
+
+Additional and more complex examples of its use can be found in the `SettingsController` and Vanilla's bundled plugins.
 
 - [Branding Page](https://github.com/vanilla/vanilla/blob/master/applications/dashboard/controllers/class.settingscontroller.php#L472-L552)
 - [Email Styles Page](https://github.com/vanilla/vanilla/blob/master/applications/dashboard/controllers/class.settingscontroller.php#L864-L893)

--- a/content/developer/addons/events-and-handlers.md
+++ b/content/developer/addons/events-and-handlers.md
@@ -120,17 +120,14 @@ public function base_render_before($sender) {
     }
 
     if(!val('UserRoles', $sender->Data)) {
-        $user = val('User', Gdn::controller());
-        if (!$user && Gdn::session()->isValid()) {
-            $user = Gdn::session()->User;
-        }
-        $userRoles = [];
-        if ($user) {
-            $userID = val('UserID', $user);
-            $userRolesData = Gdn::userModel()->getRoles($userID);
-            if ($userRolesData->numRows() > 0) {
-                $userRoles = array_column($userRolesData->resultArray(), 'Name');
+        $userRoles = val('UserRoles', $sender->Data));
+        if (!$userRoles) {
+            $user = val('User', Gdn::controller());
+            if (!$user && Gdn::session()->isValid()) {
+                $user = Gdn::session()->User;
             }
+            $userID = val('UserID', $user);
+            $userRoles = Gdn::userModel()->getRoles($userID)->resultArray();
         }
         $sender->setData('UserRoles', $userRoles);
     }
@@ -148,17 +145,17 @@ public function base_render_before($sender) {
         return;
     }
     
-    $roles = val('UserRoles', $sender->Data));
-    if (!$roles) {
+    $userRoles = val('UserRoles', $sender->Data));
+    if (!$userRoles) {
         $user = val('User', Gdn::controller());
         if (!$user && Gdn::session()->isValid()) {
             $user = Gdn::session()->User;
         }
         $userID = val('UserID', $user);
-        $roles = Gdn::userModel()->getRoles($userID)->resultArray();
+        $userRoles = Gdn::userModel()->getRoles($userID)->resultArray();
     }
 
-    $roleNames = array_column($roles, 'Name');
+    $roleNames = array_column($userRoles, 'Name');
     $isSuperSpecialRole = in_array("SuperSpecialRole", $roleNames);
     $sender->setData("isSuperSpecialRole", $isSuperSpecialRole);
 }
@@ -166,7 +163,11 @@ public function base_render_before($sender) {
 
 ### Create an additional settings page
 
-This example creates a custom dashboard page that can set a few configuration options. You would then need to use these set configuration values in other hooks to customize your site.
+This example creates a custom dashboard page that can set a few configuration options. You would then need to use these set configuration values in other hooks to customize your site. The configuration module uses Gdn_Form internally and renders an nice looking form for the dashboard. Its implementation can be found [here](https://github.com/vanilla/vanilla/blob/master/applications/dashboard/views/modules/configuration.php). Further details can be found by looking through [Gdn_Form](https://github.com/vanilla/vanilla/blob/master/library/core/class.form.php). Not all form values are supported, but additional and more complex examples of it's use can be found in the  `SettingsController` and Vanilla's bundled plugins.
+
+- [Branding Page](https://github.com/vanilla/vanilla/blob/master/applications/dashboard/controllers/class.settingscontroller.php#L472-L552)
+- [Email Styles Page](https://github.com/vanilla/vanilla/blob/master/applications/dashboard/controllers/class.settingscontroller.php#L864-L893)
+- [Google Plus Page](https://github.com/vanilla/vanilla/blob/master/plugins/GooglePlus/class.googleplus.plugin.php#L512-L520)
 
 ```php
 class MySitePlugin extends Gdn_Plugin {

--- a/content/developer/addons/events-and-handlers.md
+++ b/content/developer/addons/events-and-handlers.md
@@ -14,9 +14,6 @@ menu:
   developer:
     parent: addons
     weight: 13
-aliases:
-- /theming/hooks
-- /developer/theming/hooks
 ---
 
 Addons have the ability to listen for events fired in the rest of Vanilla and even other Addons!. This is normally done inside of a `Gdn_Plugin` but can be done inside of anything inheriting from `Gdn_Pluggable`.
@@ -109,3 +106,188 @@ With this addon enabled, going to the URL `/discussions/kaboom` would now output
 If you use a magic method to duplicate an existing method name, it will be overridden completely. And call to it will be directed to your plugin instead. The only exception is the `Index()` method.
 
 Magic methods only work in classes that extend `Gdn_Pluggable`. For example, notice the `Gdn_Form` class does, but the `Gdn_Format` class does not. All models and controllers do.
+
+## Example Events
+
+### Inject the the current user's roles into every page
+
+Sometimes you may want to adjust parts of the template based on the roles the current user. This will inject gather the roles of the current user and inject them into the smarty template.
+
+```php
+public function base_render_before($sender) {
+    if (inSection('Dashboard')) {
+        return;
+    }
+
+    if(!val('UserRoles', $sender->Data)) {
+        $user = val('User', Gdn::controller());
+        if (!$user && Gdn::session()->isValid()) {
+            $user = Gdn::session()->User;
+        }
+        $userRoles = [];
+        if ($user) {
+            $userID = val('UserID', $user);
+            $userRolesData = Gdn::userModel()->getRoles($userID);
+            if ($userRolesData->numRows() > 0) {
+                $userRoles = array_column($userRolesData->resultArray(), 'Name');
+            }
+        }
+        $sender->setData('UserRoles', $userRoles);
+    }
+}
+```
+
+### Inject a conditional based on roles
+
+Sometimes you may not need all the roles in the page. Let's say you wanted to make the page appear differently for a user with a certain role. Instead of injection all of the roles into the template and doing the conditional there, you can do it in the themehooks and inject just the boolean value you need.
+
+
+```php
+public function base_render_before($sender) {
+    if (inSection('Dashboard')) {
+        return;
+    }
+    
+    $roles = val('UserRoles', $sender->Data));
+    if (!$roles) {
+        $user = val('User', Gdn::controller());
+        if (!$user && Gdn::session()->isValid()) {
+            $user = Gdn::session()->User;
+        }
+        $userID = val('UserID', $user);
+        $roles = Gdn::userModel()->getRoles($userID)->resultArray();
+    }
+
+    $roleNames = array_column($roles, 'Name');
+    $isSuperSpecialRole = in_array("SuperSpecialRole", $roleNames);
+    $sender->setData("isSuperSpecialRole", $isSuperSpecialRole);
+}
+```
+
+### Create an additional settings page
+
+This example creates a custom dashboard page that can set a few configuration options. You would then need to use these set configuration values in other hooks to customize your site.
+
+```php
+class MySitePlugin extends Gdn_Plugin {
+     
+    /**
+     * Create the `/settings/example` page to host our custom settings.
+     *
+     * @param SettingsController $sender
+     */
+    public function settingsController_example_create($sender) {
+        $sender->permission('Garden.Settings.Manage');
+
+        $configurationModule = new ConfigurationModule($sender);
+        $configurationModule->initialize([
+            'ExmapleSite.BackgroundColour' => ['Control' => 'TextBox', 'Options' => ['class' => 'InputBox BigInput']],
+            'ExmapleSite.BackgroundImage' => ['Control' => 'ImageUpload'],
+            'ExmapleSite.BannerImage' => ['Control' => 'ImageUpload'],
+        ]);
+
+        $sender->addSideMenu();
+        $sender->setData('Title', "My Site Setttings");
+        $configurationModule->renderAll();
+    }
+
+    /**
+     * Add the "My Site" menu item.
+     *
+     * @param Gdn_Controller $sender
+     */
+    public function base_getAppSettingsMenuItems_handler($sender) {
+        /* @var SideMenuModule */
+        $menu = $sender->EventArguments['SideMenu'];
+        $menu->addLink('Appearance', t('My Site'), '/settings/example', 'Garden.Settings.Manage');
+    }
+}
+```
+
+### Add a link to the MeBox
+
+```php
+    /**
+     * Add link to drafts page to me module flyout menu.
+     *
+     * @param MeModule $sender The MeModule
+     * @param array $args Potential arguments
+     *
+     * @return void
+     */
+    public function meModule_flyoutMenu_handler($sender, $args) {
+        if (!val('Dropdown', $args, false)) {
+            return;
+        }
+        /** @var DropdownModule $dropdown */
+        $dropdown = $args['Dropdown'];
+        $dropdown->addLink(t('My Drafts'), '/drafts', 'profile.drafts', '', [], ['listItemCssClasses' => ['link-drafts']]);
+    }
+```
+
+### Add a custom location for a moderation message
+
+```php
+    /**
+     * Add custom asset location for messages
+     *
+     * @param MessageController $sender The message controller
+     * @param array $args The event arguments passed
+     *
+     * @return void
+     */
+    public function messageController_afterGetAssetData_handler($sender, $args) {
+        $possibleAssetLocations = val('AssetData', $args);
+        $possibleAssetLocations['AbovePromotedContent'] = 'Above the promoted content module';
+        setValue('AssetData', $args, $possibleAssetLocations);
+    }
+```
+
+You would then need to place this new asset somewhere in your template
+
+```tpl
+{asset name="AbovePromotedContent"}
+```
+
+### Add the Views and Comments counts to a Discussion Page
+
+```php
+    /**
+     * Adds Views and Comments count to Discussion Page
+     *
+     * @param DiscussionController $sender
+     * @param array $args
+     */
+    public function DiscussionController_AfterDiscussionTitle_handler($sender, $args) {
+        echo '<span class="Discussion-CountViews">';
+        echo t("Views").": ";
+        echo $args['Discussion']->CountViews;
+        echo '</span>';
+
+        echo '<span class="Discussion-CountComments">';
+        echo t("Reply").": ";
+        echo $args['Discussion']->CountComments;
+        echo '</span>';
+    }
+```
+
+### Add Leaderboards to the panel on the categories page
+
+{{% cloudfeature %}}
+
+```php
+    /**
+     * Adds leaderboards to Activity page
+     *
+     * @param ActivityController $sender
+     * @param array $args
+    */
+    public function categoriesController_render_before($sender, $args) {
+        if ($sender->deliveryMethod() == DELIVERY_METHOD_XHTML) {
+            $sender->addModule('LeaderBoardModule', 'Panel');
+            $module = new LeaderBoardModule();
+            $module->SlotType = 'a';
+            $sender->addModule($module);
+        }
+    }
+```

--- a/content/developer/addons/index.md
+++ b/content/developer/addons/index.md
@@ -53,7 +53,7 @@ The goal of a theme is to selectively override CSS and views in a forum.
 
 Themes can do everything a normal Addon can do, but gains the following additional functionality and requirements.
 
-- A Theme can contain a Plugin. If it does the plugin must have a classname ending in `ThemeHooks` and must have a filename containing `class.themehooks.php`. The prevailing convention results in a class `MySiteThemeHooks` and file `class.mysite.themehooks.php`.
+- A Theme can contain a Plugin. If it does the plugin must have a classname ending in `ThemeHooks` and must have a filename containing `class.themehooks.php`. The prevailing convention results in a class `MySiteThemeHooks` and file `class.mysite.themehooks.php`. See our [Theme Hooks guide](/developer/addons/theme-hooks) for more details.
 - A theme can define a [Master View](/developer/theming/views/#the-master-view) to be automatically loaded in place of the default master view.
 - A theme will automatically load a javascript file at `<mythemefolder>/js/custom.js` and a CSS file at `<mythemefolder>/design/custom.css` into the head of the site.
 - A theme can define [Theme Options](/developer/addons/theme-options) to offer an easy way to load different styles and text for a single theme.
@@ -71,5 +71,7 @@ Check out our guides to get started on a new addon or theme!
 [Addon Quickstart](/developer/addons/addon-quickstart)
 
 [Theme Quickstart](/developer/addons/theme-quickstart)
+
+[Theme Hooks](/developer/addons/theme-hooks)
 
 [Ultimate Vanilla Forums Theme Guide](http://blog.vanillaforums.com/help/vanilla-forums-themes/)

--- a/content/developer/addons/theme-hooks.md
+++ b/content/developer/addons/theme-hooks.md
@@ -99,17 +99,17 @@ There are a few common functions for a themehooks file.
 
 ### base_render_before()
 
-This runs on every single page load before the render. This includes the Dashboard so be sure to exclude it! This is also a good place to use the `Gdn_Controller` method `setData()` to inject data into your Smarty templates. 
+This runs on every single page load before the render. This includes the Dashboard so be sure to exclude it! This is also a good place to use the `Gdn_Controller` method `setData()` to inject data into your Smarty templates. For details on these controller methods, see our [framework documentation](/developer/framework/controllers/#setdata-and-data).
 
 For information about using this injected data see [Accessing Controller Data with Smarty](/developer/smarty/#accessing-controller-data-with-smarty). If you're trying to verify that the data that is getting passed into the template, try out the [{debug} function](/developer/smarty/functions/#function-debug) in smarty.
 
 ### setup()
 
-This runs when your theme is enabled. This is a good place for setting configuration values your theme may rely on, but is not required.
+This runs when when an addon is first enabled. This is a good place for setting configuration values your theme may rely on, but is not required. Sometimes it may be desirable to put most of this content inside the [structure() method](#structure) and call structure from the setup method. See the [example below](#example).
 
 ### structure()
 
-This update function is called every time you reach the `/utility/update` endpoint. Many plugins use this as a place to update the database, but it can be a good place for configuration values as well, and can be used to manually create a category, discussion, Pocket, etc that your theme relies on.
+This update function is called every time you reach the `/utility/update` endpoint. Many plugins use this as a place to update the database, but it can be a good place for configuration values as well, and can be used to manually create a category, discussion, Pocket, etc that your theme relies on. See the [example below](#example).
 
 This event is optional.
 
@@ -128,6 +128,8 @@ public function structure() {
         'Vanilla.Discussions.Layout' => 'table',
         'Garden.Thumbnail.Size' => '200',
     ]);
+
+    Pocket::touch("My Custom Pocket", "<div>My custom pocket contents</div>");
 
     return true;
 }

--- a/content/developer/addons/theme-hooks.md
+++ b/content/developer/addons/theme-hooks.md
@@ -1,0 +1,136 @@
+---
+title: Theme Hooks
+tags:
+- Theming
+- Events
+- Themehooks
+- Addon
+- Plugin
+category: developer
+menu:
+  developer:
+    parent: addons
+aliases:
+- /theming/hooks
+- /developer/theming/hooks
+---
+## Theme Hooks
+
+Themes can be imbued with the power of plugins via a special themehooks php file. Using the themehooks file, you can override existing functions in Vanilla, plug in to existing Vanilla events, and set data for your views.
+
+## Naming
+
+To use event hooks in a theme, the theme must have a plugin with a classname ending in `ThemeHooks` and must a filename containing `class.themehooks.php`. The prevailing convention results in a class `MySiteThemeHooks` and file `class.mysite.themehooks.php`. This file must be located in the root of your addon.
+
+## Events
+
+To get a better understanding of what the theme hooks are capable of, familiarize yourself with [custom events & handlers](/developer/addons/events-and-handlers), [magic events](/developer/addons/events-and-handlers/#magic-events), [example events](/developer/addons/events-and-handlers/#example-events), [function overrides](/developer/addons/function-overrides), and [magic methods](/developer/addons/events-and-handlers/#magic-methods).
+
+Here's an example of a themehooks file that sets some config variables, adds locale data for the view, adds a respond button to the discussion page, and overrides a method to add an extra css class to a menu count span.
+
+## Example Themehooks
+
+```php
+<?php
+/**
+ * @author    My Name <name@email.com>
+ * @copyright 2015 (c) My Organizations
+ * @license   http://opensource.org/licenses/MIT MIT
+ */
+
+/**
+ * Adds locale data to the view, and adds a respond button to the discussion page.
+ */
+class MyThemeNameThemeHooks extends Gdn_Plugin {
+
+    /**
+     * Fetches the current locale and sets the data for the theme view.
+     * Render the locale in a smarty template using {$locale}
+     *
+     * @param  Controller $sender The sending controller object.
+     */
+    public function base_render_before($sender) {
+        // Bail out if we're in the dashboard
+        if (inSection('Dashboard')) {
+            return;
+        }
+
+        // Fetch the currently enabled locale (en by default)
+        $locale = Gdn::locale()->current();
+        $sender->setData('locale', $locale);
+    }
+
+    /**
+     * Adds a 'respond' button on a discussion page below the discussion title
+     * that links to the comment form.
+     *
+     * @param DiscussionController $sender The sending object.
+     */
+    public function discussionController_afterDiscussionTitle_handler($sender) {
+        // Ensure the user is signed in.
+        if (Gdn::session()) {
+            echo '<div class="below-discussion-title">'.
+                 '<a class="respond-button Button" href="#Form_Comment">Respond</a>'.
+                 '</div>';
+        }
+    }
+}
+
+/**
+ * Adds a new css class to counts in the side panel filter
+ * menu in a discussion list. Overrides the method in the DiscussionFilterModule
+ * (applications/vanilla/views/modules/discussionfilter.php)
+ *
+ * @param int|null $count The number to include in the count.
+ * @param string $url The url to the popin rel for the count.
+ */
+if (!function_exists('filterCountString')) {
+    function filterCountString($count, $url = '') {
+        $count = countString($count, $url);
+        return $count != '' ? '<span class="a-new-css-class aside">'.$count.'</span>' : '';
+    }
+}
+```
+
+
+## Common Hooks
+
+There are a few common functions for a themehooks file.
+
+### base_render_before()
+
+This runs on every single page load before the render. This includes the Dashboard so be sure to exclude it! This is also a good place to use the `Gdn_Controller` method `setData()` to inject data into your Smarty templates. 
+
+For information about using this injected data see [Accessing Controller Data with Smarty](/developer/smarty/#accessing-controller-data-with-smarty). If you're trying to verify that the data that is getting passed into the template, try out the [{debug} function](/developer/smarty/functions/#function-debug) in smarty.
+
+### setup()
+
+This runs when your theme is enabled. This is a good place to any configuration values your theme may rely on, but is not required.
+
+### structure()
+
+This update function is called every time you reach the `/utility/update` endpoint. Many plugins use this as a place to update the database, but it can be a good place for configuration values as well, and can be used to manually create a category, discussion, Pocket, etc that your theme relies on.
+
+### Example
+
+Here is an example of setup and structure methods being used together.
+```php
+public function setup() {
+    $this->structure();
+}
+
+public function structure() {
+    saveToConfig([
+        'Routes.DefaultController' => array('categories', 'Internal'),
+        'Vanilla.Categories.Layout' => 'table',
+        'Vanilla.Discussions.Layout' => 'table',
+        'Garden.Thumbnail.Size' => '200',
+    ]);
+
+    return true;
+}
+```
+
+## Other Examples
+
+For more examples see our [Example Events section](/developer/addons/events-and-handlers/#example-events).

--- a/content/developer/addons/theme-hooks.md
+++ b/content/developer/addons/theme-hooks.md
@@ -105,11 +105,13 @@ For information about using this injected data see [Accessing Controller Data wi
 
 ### setup()
 
-This runs when your theme is enabled. This is a good place to any configuration values your theme may rely on, but is not required.
+This runs when your theme is enabled. This is a good place for setting configuration values your theme may rely on, but is not required.
 
 ### structure()
 
 This update function is called every time you reach the `/utility/update` endpoint. Many plugins use this as a place to update the database, but it can be a good place for configuration values as well, and can be used to manually create a category, discussion, Pocket, etc that your theme relies on.
+
+This event is optional.
 
 ### Example
 

--- a/content/developer/addons/view-overrides.md
+++ b/content/developer/addons/view-overrides.md
@@ -123,7 +123,12 @@ To see how it all fits together, here's a default master view using Smarty:
 
 ## Overriding other views
 
-Now that you know how to override and configure the master view, you may want to configure the content of the assets and modules. Before we get there though, a warning: overriding a view can be a rather severe addition to a theme. Once a view is overridden, it diverges from core Vanilla. As such, your new view may not always be supported in future versions of Vanilla, which may cause problems down the road. If it's possible to accomplish what you're trying to do using good ol' CSS, or [event handlers](/developer/addons/events-and-handlers), or by being clever with the configuration of your master view, those are probably better ways to go.
+Now that you know how to override and configure the master view, you may want to configure the content of the assets and modules. Before we get there though, a warning: overriding a view can be a rather severe addition to a theme. Once a view is overridden, it diverges from core Vanilla. As such, **your new view may not always be supported** in future versions of Vanilla, which may cause problems down the road. 
+
+If possible first:
+
+- Try to accomplish what you're doing using good ol' CSS. A strong knowledge of CSS can allow you to make powerful customizations to your Vanilla Forum while being simpler, stabler, and more maintainable. The Vanilla Forums markup isn't perfect, but it's a lot easier down the road to tweak a few custom styles then to reconcile a totally custom view with the original if the shape of the data changes, or the view is refactored.
+- Try to use an [event handlers](/developer/addons/events-and-handlers) to accomplish your change. Vanilla's event handlers are incredibly powerful and there are events everywhere.
 
 With that warning out of the way, here's how you can override a view in Vanilla. Some plugins and every application contains a views folder. To override any file in this folder:
 

--- a/content/developer/addons/view-overrides.md
+++ b/content/developer/addons/view-overrides.md
@@ -127,7 +127,7 @@ Now that you know how to override and configure the master view, you may want to
 
 If possible first:
 
-- Try to accomplish what you're doing using good ol' CSS. A strong knowledge of CSS can allow you to make powerful customizations to your Vanilla Forum while being simpler, stabler, and more maintainable. The Vanilla Forums markup isn't perfect, but it's a lot easier down the road to tweak a few custom styles then to reconcile a totally custom view with the original if the shape of the data changes, or the view is refactored.
+- Try to accomplish what you're doing using good ol' CSS. A strong knowledge of CSS can allow you to make powerful customizations to your Vanilla Forum while being simpler, stabler, and more maintainable. Even if the markup isn't exactly what you need for *your use case*, it's a lot easier down the road to tweak a few custom styles than to reconcile a totally custom view with the original if the shape of the data changes, or the view is refactored. The risk of your own code breaking with future versions of Vanilla is much lower as well.
 - Try to use [event handlers](/developer/addons/events-and-handlers) to accomplish your change. Vanilla's event handlers are incredibly powerful and there are events everywhere.
 
 With that warning out of the way, here's how you can override a view in Vanilla. Some plugins and every application contains a views folder. To override any file in this folder:

--- a/content/developer/addons/view-overrides.md
+++ b/content/developer/addons/view-overrides.md
@@ -128,7 +128,7 @@ Now that you know how to override and configure the master view, you may want to
 If possible first:
 
 - Try to accomplish what you're doing using good ol' CSS. A strong knowledge of CSS can allow you to make powerful customizations to your Vanilla Forum while being simpler, stabler, and more maintainable. The Vanilla Forums markup isn't perfect, but it's a lot easier down the road to tweak a few custom styles then to reconcile a totally custom view with the original if the shape of the data changes, or the view is refactored.
-- Try to use an [event handlers](/developer/addons/events-and-handlers) to accomplish your change. Vanilla's event handlers are incredibly powerful and there are events everywhere.
+- Try to use [event handlers](/developer/addons/events-and-handlers) to accomplish your change. Vanilla's event handlers are incredibly powerful and there are events everywhere.
 
 With that warning out of the way, here's how you can override a view in Vanilla. Some plugins and every application contains a views folder. To override any file in this folder:
 

--- a/content/developer/framework/controllers.md
+++ b/content/developer/framework/controllers.md
@@ -3,6 +3,8 @@ title: Controllers & URLs
 tags:
 - Developers
 - Framework
+- Controllers
+- Urls
 category: developer
 menu:
   developer:
@@ -11,15 +13,14 @@ menu:
 aliases:
 - /developers/framework/controllers
 ---
-## Controllers
 
 In our MVC context, controllers are the traffic cops. They receive a parsed request (typically the URL in the address bar), build some data using models, and send it back to the browser in a view.
 
-### Dispatcher
+## Dispatcher
 
 Vanilla maps URLs to controllers in a fairly direct way. The Dispatcher (`Gdn_Dispatcher`) receives incoming [requests](/developer/framework/requests) and invokes the appropriate controller(s).
 
-### Mapping URLs
+## Mapping URLs
 
 First it looks for an application name, then a controller name, then a method name, then any arguments which will be passed in the order given. 
 
@@ -32,7 +33,7 @@ $ProfileController->notifications('1', 'Lincoln');
 
 If the application is omitted, it will automatically search enabled applications for a suitably named controller. Therefore, avoid controller name overlap. If the method name is omitted, the `Index()` method will be invoked. Therefore, the basic profile URL `/profile/1/Lincoln` could be more verbosely written as `/dashboard/profile/index/1/Lincoln` to more clearly understand what code it is invoking.
 
-### Pretty URLs
+## Pretty URLs
 
 All requests are dispatched thru the index.php file. While it's possible to use the framework by passing a 'p' parameter with the rest of the path (e.g. `/index.php?p=/profile`), it's best to configure your server to handle "pretty" URLs.
 
@@ -52,3 +53,27 @@ Vanilla will attempt to detect whether your system can handle pretty URLs during
 $Configuration['Garden']['RewriteUrls'] = TRUE;
 ```
 The ability to use non-pretty URLs may be deprecated in the future.
+
+
+## `setData()` and `data()`
+
+Each controller contains an array of data that get's passed into it's view & templates for rendering. While it's possible to work with the `$controller->Data` object directly this is discouraged. Instead two functions utility functions are provided to fetch directly from the $Data array.
+
+Data is read and written using [dot notation](/developer/configuration).
+
+### data
+
+The `data()` function takes 2 parameters.
+
+- {string} $path - The data path to look up in dot notation.
+- {mixed} $default - The value to return if no data is found. Defaults to an empty string.
+
+### setData
+
+The `setData` function takes 3 properties.
+
+- {string} $path - the path to set the data at.
+- {mixed} $value - The value to set for the data.
+- {bool} $addProperty - Optionaly set the path directly on the controller in addition to the $Data array.
+
+Alternatively `setData` can be passed an array of multiple `$path => $value` pairs instead of the 3 parameters. In this case each of these paths will be set in the $Data array with their given values.

--- a/content/developer/smarty/functions.md
+++ b/content/developer/smarty/functions.md
@@ -38,7 +38,7 @@ You are also able to use the [built-in Smarty functions](http://www.smarty.net/d
 
 Opens up the Smarty debug console in a popup window. This will show you all of the data available to the smarty template. This data matches the `data` attribute on the page's controller. 
 
-Additional data can be easily added by using the `setData()` method. See the [themehooks documentation for detail](/developer/addons/theme-hooks/#base_render_before).
+Additional data can be easily added by using the `setData()` method. See the [themehooks documentation for detail](/developer/addons/theme-hooks/#example-themehooks).
 
 ### Usage
 

--- a/content/developer/smarty/functions.md
+++ b/content/developer/smarty/functions.md
@@ -34,6 +34,17 @@ This section outlines all the Vanilla-specific Smarty functions made available f
 
 You are also able to use the [built-in Smarty functions](http://www.smarty.net/docsv2/en/language.custom.functions.tpl) in your template.
 
+## Function: `{debug}`
+
+Opens up the Smarty debug console in a popup window. This will show you all of the data available to the smarty template. This data matches the `data` attribute on the page's controller. 
+
+Additional data can be easily added by using the `setData()` method. See the [themehooks documentation for detail](/developer/addons/theme-hooks/#base_render_before).
+
+### Usage
+
+```tpl
+{debug}
+```
 
 ## Function: `{asset}`
 


### PR DESCRIPTION
Closes #201 

I've added back the old example and a lot of additional ones. I also refreshed most of the links. I moved the redirects from the old themehooks page that were on the events and handlers page to the new themehooks page.