### PR TITLE
Add pagination section to APIv2 doc

### DIFF
--- a/content/apiv2/index.md
+++ b/content/apiv2/index.md
@@ -30,23 +30,18 @@ We use 2 types of pagination in the API:
   - Used where possible.
   - Have access to First, Last, Prev and Next pages.
 - More pagination
-  - Used where querying the total count of a particular resource would be bad performance wise.
+  - Used where querying the totals of a particular resource would not be performant.
   - Have access to First, Prev and Next pages.
 
-Resources that supports pagination
+Resources that support pagination have `page` and `limit` parameters. For example: `/api/v2/{RESOURCE}?page={PAGE_NUM}&limit={NUM_ITEMS}`
 
-- Have the "page" and "limit" parameter.
-- Can be browsed like so: `/api/v2/{RESOURCE}?page={PAGE_NUM}&limit={NUM_ITEMS}`
+Since the API returns an array of records, the paging information is sent through HTTP headers. Depending on the pagination type, the following headers are returned (all values are represented as relative URLs):
 
-Since the API returns an array of records the paging information are sent through the HTTP header.
-Depending on the pagination type, the following headers are returned:
-
-- `Paging-First`: Relative URL to the first page of records.
-- `Paging-Last`: Relative URL to the last page of records.
-- `Paging-Prev`: Relative URL to the previous page of records. *Only available if page > 1*
-- `Paging-Next`: Relative URL to the next page of records. *Only available if more records are available*
+- `Paging-First`: First page of records.
+- `Paging-Last`: Last page of records.
+- `Paging-Prev`: Previous page of records. *Only available if page > 1.*
+- `Paging-Next`: Next page of records. *Only available if more records are available.*
 
 
-*Note that __results per pages__ can be lower than __limit__ even if more pages are available 
-due to records being filtered because of permissions. It is also possible to have empty pages because of that.
-To know for sure if more records are available check if `Paging-Next` is present in the header.*
+*Note that __results per pages__ can be lower than __limit__ even if more pages are available. This is due to rows being removed based on the current user's permissions. It is also possible to have empty pages for the same reason.
+ The `Paging-Next` header will always be present when more rows are available.*

--- a/content/apiv2/index.md
+++ b/content/apiv2/index.md
@@ -19,3 +19,34 @@ We've rebuilt Vanilla's API from the ground up to enable tighter integrations an
 - Cross-origin resource sharing (CORS) support.
 - Greater functional consistency, and higher conformance to current industry best practices.
 - Better automated testing, to reduce regression bugs and unwanted changes.
+
+## Features
+
+### Pagination
+
+We use 2 types of pagination in the API:
+
+- Numbered pagination
+  - Used where possible.
+  - Have access to First, Last, Prev and Next pages.
+- More pagination
+  - Used where querying the total count of a particular resource would be bad performance wise.
+  - Have access to First, Prev and Next pages.
+
+Resources that supports pagination
+
+- Have the "page" and "limit" parameter.
+- Can be browsed like so: `/api/v2/{RESOURCE}?page={PAGE_NUM}&limit={NUM_ITEMS}`
+
+Since the API returns an array of records the paging information are sent through the HTTP header.
+Depending on the pagination type, the following headers are returned:
+
+- `Paging-First`: Relative URL to the first page of records.
+- `Paging-Last`: Relative URL to the last page of records.
+- `Paging-Prev`: Relative URL to the previous page of records. *Only available if page > 1*
+- `Paging-Next`: Relative URL to the next page of records. *Only available if more records are available*
+
+
+*Note that __results per pages__ can be lower than __limit__ even if more pages are available 
+due to records being filtered because of permissions. It is also possible to have empty pages because of that.
+To know for sure if more records are available check if `Paging-Next` is present in the header.*


### PR DESCRIPTION
Fixes https://github.com/vanilla/vanilla/issues/6069

Explain APIv2 pagination
- Header links
- Variable number of results / empty pages
- Numbered vs More pagination type