### PR TITLE
 Expand the SSO General principles section

### DIFF
--- a/content/help/sso/index.md
+++ b/content/help/sso/index.md
@@ -37,53 +37,52 @@ All flavors and types of SSO follow general rules in Vanilla, many of which are 
 
 ## General principles
 
-Regardless of your type of SSO, the following principles/recommendations apply to how Vanilla handles it:
+Regardless of your type of SSO, the following principles/recommendations apply to how it is handled by Vanilla:
 
-- Since you are the provider you have to make sure that the information you pass through SSO are validated. 
+- Since you are the provider, make sure that the information you pass through SSO is already validated.
 Email addresses, for example, **should be already confirmed** on your side before a user is allowed to connect through SSO.
-- We strongly recommend against creating new users over the API.
+- It is strongly recommend you do not create users over the API.
 The fault-tolerant way to map users to your forum is to always let them be asynchronously created as they login.
 
 ### Account connection
 
 When a user logs in through SSO for the first time, a connection is made using the SSO UniqueID and Vanilla UserID.
-That connection is remembered forever and future change to user information are irrelevant.
-ie. If the user changes his email address after the first connection it won't causes any problem.
+The connection between the two IDs is permanent for that connection. If the user changes their email address after the first connection it won't causes any problem.
 
 Generally, two things can happen when that connection is being made:
 
-- All the required information are passed through SSO and their do not match any user account on the forum.
+- All the required information is correctly passed through SSO and no matching Vanilla user is found.
    - This will result in a brand new user created on the forum.
-- Some required information are missing or some information match an existing user account on the forum. 
-   - The user will be redirected to an interstitial page where he will have to either:
+- Some required information is missing or some information matches an existing user account on the forum.
+   - The user will be redirected to a page where he will have to either:
       - Fill out the missing information.
       - Manually connect to an existing forum account by specifying the password of that account. 
-      *This ensure that the user owns the forum's account.*
-      - Create a new account with a name/email that does not conflict with an existing forum account.
+      *This ensures the user owns the forum's account.*
+      - Create a new account with a username/email that does not conflict with an existing forum account.
 
-*Omitting one required information, for example username (often 'name'), will send the user to that interstitial page.*
+*Omitting one required field, for example username (often 'name'), will prompt the user to fill in the information.*
 
 ### AutoConnect
 
 AutoConnect is a feature that uses email addresses to automatically connect an account in the [Account connection](#account-connection) process.
 When this feature is enabled, and the email passed through SSO matches the email of a user account on the forum,
 the connection between the SSO UniqueID and Vanilla UserID is made right away without the user having to go 
-through the interstitial page to confirm its ownership over an account.
+through confirming ownership over an existing account.
 
 For *security reasons* it must be opted into.
 Email addresses **must be validated on your side** when using this feature..
 
-*We __only__ connect to existing accounts by matching email address. No exceptions.* 
+*Vanilla __only__ connects existing accounts by matching email address. No exceptions.*
 
 ### Redirection
 
-*Most SSO solution honour this behavior.*
+*Most SSO solutions honor this behavior.*
 
-When tightening your SSO configurations to redirect users automatically after the Sign In process, you can use `{target}` in the redirect URL.
+When tightening your SSO configurations to redirect users automatically after the sign-in process, you can use `{target}` in the redirect URL.
 Vanilla will replace `{target}` by the page the user is currently on when generating the URL.
 
 Example (using jsConnect): `https://sso.example.com/jsconnect/signin?redirect={target}` would become something like
-`https://sso.vanilla.localhost/jsconnect/signin?redirect=/discussions`
+`https://sso.example.com/jsconnect/signin?redirect=/discussions`
 
 ## Logging users out
 

--- a/content/help/sso/index.md
+++ b/content/help/sso/index.md
@@ -29,7 +29,6 @@ Vanilla offers three flavors of single sign-on:
 
 We also offer:
 
-
 * Social SSO (Twitter, Facebook, and more).
 * Third-party service integration (e.g. Auth0; cloud-only).
 * Custom SSO integrations (cloud-only).
@@ -38,13 +37,53 @@ All flavors and types of SSO follow general rules in Vanilla, many of which are 
 
 ## General principles
 
-Regardless of your type of SSO, these principles apply to how Vanilla handles it:
+Regardless of your type of SSO, the following principles/recommendations apply to how Vanilla handles it:
 
-* We recommend against creating new users over the API. The fault-tolerant way to map users to your forum is to always let them be asynchronously created as they login.
-* We **only** connect to existing accounts by matching email address. No exceptions. Automatic account connection must be opted into for security reasons. 
-* Once a connection is made to an account, the connection is remembered forever. Future email address changes are irrelevant.
-* Omitting the parameter for username (often 'name') will send the user to an interstitial page that prompts them to create one.
+- Since you are the provider you have to make sure that the information you pass through SSO are validated. 
+Email addresses, for example, **should be already confirmed** on your side before a user is allowed to connect through SSO.
+- We strongly recommend against creating new users over the API.
+The fault-tolerant way to map users to your forum is to always let them be asynchronously created as they login.
 
+### Account connection
+
+When a user logs in through SSO for the first time, a connection is made using the SSO UniqueID and Vanilla UserID.
+That connection is remembered forever and future change to user information are irrelevant.
+ie. If the user changes his email address after the first connection it won't causes any problem.
+
+Generally, two things can happen when that connection is being made:
+
+- All the required information are passed through SSO and their do not match any user account on the forum.
+   - This will result in a brand new user created on the forum.
+- Some required information are missing or some information match an existing user account on the forum. 
+   - The user will be redirected to an interstitial page where he will have to either:
+      - Fill out the missing information.
+      - Manually connect to an existing forum account by specifying the password of that account. 
+      *This ensure that the user owns the forum's account.*
+      - Create a new account with a name/email that does not conflict with an existing forum account.
+
+*Omitting one required information, for example username (often 'name'), will send the user to that interstitial page.*
+
+### AutoConnect
+
+AutoConnect is a feature that uses email addresses to automatically connect an account in the [Account connection](#account-connection) process.
+When this feature is enabled, and the email passed through SSO matches the email of a user account on the forum,
+the connection between the SSO UniqueID and Vanilla UserID is made right away without the user having to go 
+through the interstitial page to confirm its ownership over an account.
+
+For *security reasons* it must be opted into.
+Email addresses **must be validated on your side** when using this feature..
+
+*We __only__ connect to existing accounts by matching email address. No exceptions.* 
+
+### Redirection
+
+*Most SSO solution honour this behavior.*
+
+When tightening your SSO configurations to redirect users automatically after the Sign In process, you can use `{target}` in the redirect URL.
+Vanilla will replace `{target}` by the page the user is currently on when generating the URL.
+
+Example (using jsConnect): `https://sso.example.com/jsconnect/signin?redirect={target}` would become something like
+`https://sso.vanilla.localhost/jsconnect/signin?redirect=/discussions`
 
 ## Logging users out
 

--- a/content/help/sso/jsconnect/index.md
+++ b/content/help/sso/jsconnect/index.md
@@ -223,7 +223,7 @@ Consider the embed code for Vanilla comments:
 
 /*** Required Settings: Edit BEFORE pasting into your web page ***/
 
-var vanilla_forum_url = 'http://your.url.com/'; // The full http url &amp; path to your vanilla forum
+var vanilla_forum_url = 'http://forum.example.com/'; // The full http url &amp; path to your vanilla forum
 var vanilla_identifier = 'your-content-identifier'; // Your unique identifier for the content being commented on
 **var vanilla_sso = 'SSO STRING'; // Your SSO string.**
 
@@ -267,7 +267,6 @@ That's it! The value of vanilla_sso from above is what you put in your embed cod
 - Even though your signature string is base64 encoded make sure the actual signature is hex encoded. The correct string will be 40 characters consisting of the numbers 0-9 and a-f.
 - The timestamp is a unix timestamp. That means it will be an integer and represents the number of seconds since 1 January 1970. Most languages have a way of getting this timestamp.
 
-
 ## WordPress plugin
 
-If your site is using WordPress then we make a plugin that allows you to use SSO with your WordPress site. It also helps you set up an embedded forum and embedded comments on your site. <a href="https://wordpress.org/plugins/vanilla-forums/" target="_blank">Get the plugin</a>.
+If your site is using WordPress then we make a plugin that allows you to use SSO with your WordPress site. It also helps you set up an embedded forum and embedded comments on your site. <a href="https://wordpress.org/plugins/vanilla-forums/" target="_blank" rel="nofollow noopener">Get the plugin</a>.


### PR DESCRIPTION
Fixes https://github.com/vanilla/docs/issues/95

Add explanation about:
- Account connection
- AutoConnect feature
- Magic `{target}` value

Put more emphasis on some details like information validity (especially emails).