### PR TITLE
Fix swagger query config injection

### DIFF
--- a/static/js/swagger/swagger-ui-plugin.js
+++ b/static/js/swagger/swagger-ui-plugin.js
@@ -8,6 +8,12 @@ jQuery(document).ready(function($) {
         }
     }
 
+    // We actually can't prevent SwaggerUI from overwriting the set URL with one in the query string.
+    // https://github.com/swagger-api/swagger-ui/issues/4332
+    if (window.location.search) {
+        window.location.search = "";
+    }
+
     window.ui = SwaggerUIBundle({
         url: '/js/swagger/swagger-data.json',
         dom_id: '#swagger-ui',


### PR DESCRIPTION
Closes https://github.com/vanilla/vanilla-patches/issues/179

Apparently swagger allows any configuration variable to be overridden through a query parameter and currently has no way to disable this functionality. 

I've opened an issue here https://github.com/swagger-api/swagger-ui/issues/4332 and have added a bit of javascript to strip off query parameters before loading swagger-ui. It's not the perfect solution, but there is not much else we can do here without forking/upstreaming a fix into swagger-ui. I'm open to doing that, but want to make sure it would be accepted first.