### PR TITLE
Update build tool documentation

### DIFF
--- a/content/developer/vanilla-cli/build-process-core.md
+++ b/content/developer/vanilla-cli/build-process-core.md
@@ -19,7 +19,7 @@ versioning:
   added: 2.6
 ---
 
-This is the primary Vanilla Forums build process. It is used to build assets for vanilla's core, and it's addons. It is build using [Webpack](https://webpack.js.org/), [node-sass](https://github.com/sass/node-sass) and [babel](https://babeljs.io/). The `core` process can generate multiple javascript bundles and multiple built stylesheets for an addon. Its primary differences from the v1 process is that it enables building against other addons. Code can be shared between addons by using [dependency bundles](#dependency-bundles) and [child themes](#child-themes).
+This is the primary Vanilla Forums build process. It is used to build assets for vanilla's core, and it's addons. It is built using [Webpack](https://webpack.js.org/), [node-sass](https://github.com/sass/node-sass), [babel](https://babeljs.io/), and [typescript](https://https://www.typescriptlang.org/). The `core` process can generate multiple javascript bundles and multiple built stylesheets for an addon. Its primary differences from the v1 process is that it enables building against other addons. Code can be shared between addons by using [dependency bundles](#dependency-bundles) and [child themes](#child-themes).
 
 ## Contents
 
@@ -56,6 +56,39 @@ Dependency Bundles are used to separate out common chunks of code from between a
 
 would generate bundles `js/lib-dashboard-app.js` and `js/lib-dashboard-admin.js` and manifests `manifests/app-manifest.json` and `manifests/admin-manifest.json`
 
+### The * Export
+
+Oftentimes you can have files that need to get exported into for every section. In this case you can use the `*` export. It's export will be applied for every other section. Keep in mind that the sections do need to still have an export key, even if its empty.
+
+```json
+"build": {
+    "key": "core",
+    "process": "core",
+    "exports": {
+        "*": [
+            "./src/scripts/application",
+            "./src/scripts/gdn",
+            "./src/scripts/permissions",
+            "./src/scripts/utility",
+            "./src/scripts/dom-utility",
+            "./src/scripts/Components/DocumentTitle",
+            "./src/scripts/Main/NotFoundPage",
+            "axios",
+            "classnames",
+            "moment",
+            "react",
+            "react-dom",
+            "react-redux",
+            "redux",
+            "prop-types",
+            "sprintf-js"
+        ],
+        "app": [],
+        "admin": []
+    }
+}
+```
+
 ### What should go into a dependency bundle?
 
 - Modular code that you want to consume from your own addon and/or other addons.
@@ -84,7 +117,7 @@ Some aliases have been provided to make importing slightly easier.
 ```js
 import * as React from "react";
 import { Modal } from "@dashboard/app/components";
-import Editor from "@vanilla-editor/editor";
+import editorEvents from "@rich-editor/events";
 import Events from "@core/events";
 ```
 

--- a/content/developer/vanilla-cli/build-process-core.md
+++ b/content/developer/vanilla-cli/build-process-core.md
@@ -19,7 +19,14 @@ versioning:
   added: 2.6
 ---
 
-This is the primary Vanilla Forums build process. It is used to build assets for vanilla's core, and it's addons. It is built using [Webpack](https://webpack.js.org/), [node-sass](https://github.com/sass/node-sass), [babel](https://babeljs.io/), and [typescript](https://https://www.typescriptlang.org/). The `core` process can generate multiple javascript bundles and multiple built stylesheets for an addon. Its primary differences from the v1 process is that it enables building against other addons. Code can be shared between addons by using [dependency bundles](#dependency-bundles) and [child themes](#child-themes).
+This is the primary Vanilla Forums build process. It is used to build assets for vanilla's core, and it's addons. It's tooling includes
+
+- [Webpack](https://webpack.js.org/)
+- [node-sass](https://github.com/sass/node-sass)
+- [babel](https://babeljs.io/)
+- [typescript](https://https://www.typescriptlang.org/)
+
+The `core` process can generate multiple script bundles and multiple built stylesheets for an addon. Its primary differences from the `v1` process is that it enables building against other addons. Code can be shared between addons by using [dependency bundles](#dependency-bundles) and [child themes](#child-themes). It also allows for more complex file structures and has [typescript support](/developer/vanilla-cli/bundling-process#typescript).
 
 ## Contents
 
@@ -34,9 +41,9 @@ This is the primary Vanilla Forums build process. It is used to build assets for
 
 Source files are always found in one of two places - the `src` directory or the `node_modules` directory. Node modules can be installed from [npm](https://www.npmjs.com/) with [yarn](https://yarnpkg.com/en/).
 
-Javascript source files are located in the `src/scripts` directory and built into the `js` directory of the addon. Stylesheet source files (Sass) are located in the `src/scss` directory and are built into the `design` directory of the addon.
+Javascript or typescript source files are located in the `src/scripts` directory and built into the `js` directory of the addon. Stylesheet source files (Sass) are located in the `src/scss` directory and are built into the `design` directory of the addon.
 
-Javascript entry points must be explicitly defined in the [addon.json file](/developer/addons/addon-info#build). Stylesheet entry points are inferred. Any file matching the pattern `src/scss/**/*.scss` that does not match `_*.scss` will be used as an entry point.
+Javascript or typescript entry points must be explicitly defined in the [addon.json file](/developer/addons/addon-info#build). Stylesheet entry points are inferred. Any file matching the pattern `src/scss/**/*.scss` that does not match `_*.scss` will be used as an entry point.
 
 ## Dependency Bundles
 Dependency bundles are built from the files defined in `build.exports` of the [addon.json file](/developer/addons/addon-info/#build-exports).
@@ -58,7 +65,7 @@ would generate bundles `js/lib-dashboard-app.js` and `js/lib-dashboard-admin.js`
 
 ### The * Export
 
-Oftentimes you can have files that need to get exported into for every section. In this case you can use the `*` export. It's export will be applied for every other section. Keep in mind that the sections do need to still have an export key, even if its empty.
+Oftentimes you can have files that need to get exported into for every section. In this case you can use the `*` export. Its exports will be applied for every other section. Keep in mind that sections still need to have an export key, even if they are empty.
 
 ```json
 "build": {
@@ -226,4 +233,4 @@ If you create these two files in `themes/child-theme/src/scss` their contents wi
 
 ## Bundling Process
 
-See the [Bundling Process](/developer/vanilla-cli/bundling-process) page for details about the CLI bundles it's assets and the transforms that can be applied to javascript through the build process.
+See the [Bundling Process](/developer/vanilla-cli/bundling-process) page for details about the CLI bundles it's assets and the transforms that can be applied to javascript or typescript through the build process.

--- a/content/developer/vanilla-cli/bundling-process.md
+++ b/content/developer/vanilla-cli/bundling-process.md
@@ -5,6 +5,7 @@ tags:
 - CLI
 - Build
 - Javascript
+- Typescript
 - Import
 - Bundle
 - Webpack
@@ -19,9 +20,19 @@ versioning:
 
 The Vanilla CLI's sass and javascript build processes provide multiple methods to import other sass/css or javascript files. *This only works with the built-in build processes.*
 
+## Typescript
+
+{{% versioning added="2.6" %}}
+
+The `core` and `v1` build process now contain support for typescript. Typescript files can import javascript files, and javascript files can import typescript files. If your not familiar with typescript, see the [typescript website](https://www.typescriptlang.org/).
+
+The typescript config being used will be the `tsconfig.json` at the top of your local Vanilla Forums installation.
+
 ## Javascript
 
 The javascript files are bundled *not concatenated*. Concatenation is how many legacy process work. A legacy build script would need to define the order that javscript files would get loaded in and they would get attatched to each other in order. Each file would place their contents in the global namespace and rely on their particular order to only reference things loaded before themselves. Bundling allows import/require statements to be resolved dynamically, and be deduplicated. All dependancies must be implicitly defined at the top of each file.
+
+The babel preset used will be [@vanillaforums/babel-preset](https://github.com/vanilla/babel-preset).
 
 ### Syntax
 

--- a/content/developer/vanilla-cli/bundling-process.md
+++ b/content/developer/vanilla-cli/bundling-process.md
@@ -20,14 +20,6 @@ versioning:
 
 The Vanilla CLI's sass and javascript build processes provide multiple methods to import other sass/css or javascript files. *This only works with the built-in build processes.*
 
-## Typescript
-
-{{% versioning added="2.6" %}}
-
-The `core` and `v1` build process now contain support for typescript. Typescript files can import javascript files, and javascript files can import typescript files. If your not familiar with typescript, see the [typescript website](https://www.typescriptlang.org/).
-
-The typescript config being used will be the `tsconfig.json` at the top of your local Vanilla Forums installation.
-
 ## Javascript
 
 The javascript files are bundled *not concatenated*. Concatenation is how many legacy process work. A legacy build script would need to define the order that javscript files would get loaded in and they would get attatched to each other in order. Each file would place their contents in the global namespace and rely on their particular order to only reference things loaded before themselves. Bundling allows import/require statements to be resolved dynamically, and be deduplicated. All dependancies must be implicitly defined at the top of each file.
@@ -53,6 +45,7 @@ All ES2017 syntax and features are supported, including
 - `Map`/`Set`
 - `Array.prototype.map`/`Array.prototype.reduce`/`Array.prototype.filter`
 - `import`/`export`
+- `JSX` support
 
 ### Methods of exporting javascript
 
@@ -141,6 +134,17 @@ import {someOtherFunction} from "../sibling-file";
 ```
 
 If you are importing a file ending in `.js` or `.jsx` you do not need to and should not provide a file extension.
+
+
+## Typescript
+
+{{% versioning added="2.6" %}}
+
+The `core` build process now supports typescript. If you're not familiar with typescript, see the [typescript website](https://www.typescriptlang.org/).
+
+Typescript files are interoperable with javascript in this build process. A typescript file can import a javascript file and vice-versa. The only change you need to make for this build tool to interpret your javascript file as a typescript file is to rename the file extension from `js` to `ts` or from `jsx` to `tsx`. Because of this, it is recommended that your write you're script imports _without_ a file extension on them. The build tool will infer the file extension based on the actual file that exists. This allows easier migration from one extension to another if a file is converted to typescript or to support JSX.
+
+The typescript config being used will be the `tsconfig.json` at the top of your local Vanilla Forums installation.
 
 ## Sass
 

--- a/current-links.json
+++ b/current-links.json
@@ -297,6 +297,7 @@
     "http://127.0.0.1:1313/tags/training/",
     "http://127.0.0.1:1313/tags/troubleshooting/",
     "http://127.0.0.1:1313/tags/twitter/",
+    "http://127.0.0.1:1313/tags/typescript/",
     "http://127.0.0.1:1313/tags/urls/",
     "http://127.0.0.1:1313/tags/v1/",
     "http://127.0.0.1:1313/tags/vanilla-pop/",


### PR DESCRIPTION
Closes #252 

- Documents the * exports key
- Documents typescript support. This PR is just covering the build tooling part of the support. Our typescript conventions intro, etc will come in a later PR.