### PR TITLE
Fix Variable, Method And Function Names To Start With Lower Case Letters

### DIFF
--- a/content/developer/addons/events-and-handlers.md
+++ b/content/developer/addons/events-and-handlers.md
@@ -33,7 +33,7 @@ $this->fireEvent('EventName');
 ```
 and then Plugins can attach to that event to perform an action.
 
-There is an AddonManager that detects any enabled addons. When the `FireEvent` method is called, it pings the AddonManager class to see if there are any addons that want to attach to the event name being fired.
+There is an AddonManager that detects any enabled addons. When the `fireEvent` method is called, it pings the AddonManager class to see if there are any addons that want to attach to the event name being fired.
 
 Addons attach to an event by creating a method named with the object name, event name, and the word `handler` separated by underscores. Say the `DiscussionsController` fired an event named 'Kaboom'. Here is how you would use it:
 
@@ -107,7 +107,7 @@ class MyPlugin extends Gdn_Plugin {
 
 With this addon enabled, going to the URL `/discussions/kaboom` would now output the text "Kaboom!". You can references other methods and properties on the extended object using the `$sender` variable.
 
-If you use a magic method to duplicate an existing method name, it will be overridden completely. And call to it will be directed to your plugin instead. The only exception is the `Index()` method.
+If you use a magic method to duplicate an existing method name, it will be overridden completely. And call to it will be directed to your plugin instead. The only exception is the `index()` method.
 
 Magic methods only work in classes that extend `Gdn_Pluggable`. For example, notice the `Gdn_Form` class does, but the `Gdn_Format` class does not. All models and controllers do.
 

--- a/content/developer/apiv2/authentication.md
+++ b/content/developer/apiv2/authentication.md
@@ -27,7 +27,7 @@ There isn't a built-in user interface for issuing access tokens (yet). Right now
 ```php
 // Issue a token
 $model = new AccessTokenModel();
-$accessToken = $model->issue(Gdn::session()->UserID(), '1 month', $scope);
+$accessToken = $model->issue(Gdn::session()->UserID, '1 month', $scope);
 
 // Verify a token.
 $tokenRow = $model->verify($accessToken);

--- a/content/developer/changelog/index.md
+++ b/content/developer/changelog/index.md
@@ -243,11 +243,11 @@ Major Features:
 
 Changes:
 
-* Added ability to chain Vanillicons into Gravatars with C(Plugins.Gravatar.UseVanillicons) = TRUE
+* Added ability to chain Vanillicons into Gravatars with c(Plugins.Gravatar.UseVanillicons) = true
 * Added ability to use IE targetting for CSS and JS files
 * Disabled CLEditor for IE6 users
 * Disabled popups in IE7 or less
-* Added Session support, see: Gdn_Session()->Stash()
+* Added Session support, see: Gdn_Session()->stash()
 * Turns off Embed by default
 * Added WebOS to mobile user agents
 

--- a/content/developer/configuration/using.md
+++ b/content/developer/configuration/using.md
@@ -21,7 +21,7 @@ If you have large quantities of data or data that is written frequently, conside
 The `c` function is the appropriate shortcut for reading from the config. The first parameter is the name of the config value in [dot notation](/developer/configuration). The second is an optional default value to return if requested config setting is not defined.
 
 Example:
-`$Value = c('Name.Of.Setting', 'DefaultValue');`
+`$value = c('Name.Of.Setting', 'DefaultValue');`
 
 You can call a partial config key to get an array of all values below it in dot notation. For instance, say this was in your config:
 
@@ -34,13 +34,13 @@ Now calling `c('Examples.Settings');` will return `array('A'=>1, 'B'=>2)`.
 
 ## Writing to config
 
-Save to the config with the `SaveToConfig` function. It takes the name of the config value, a new value to associate with it, and an optional options array. In the options array, you can pass the key `Save` with the value `FALSE` to make the config change only apply for this pageload.
+Save to the config with the `saveToConfig` function. It takes the name of the config value, a new value to associate with it, and an optional options array. In the options array, you can pass the key `Save` with the value `false` to make the config change only apply for this pageload.
 
-Change a config setting permanently: `SaveToConfig('Name.Of.Setting', 'NewValue');`
+Change a config setting permanently: `saveToConfig('Name.Of.Setting', 'NewValue');`
 
-Change a config setting only for this pageload: `SaveToConfig('Name.Of.Setting', 'NewValue', array('Save' => FALSE));`
+Change a config setting only for this pageload: `saveToConfig('Name.Of.Setting', 'NewValue', array('Save' => false));`
 
-Simply passing the value `FALSE` in place of the options array has the same effect as passing `array('Save' => FALSE)`.
+Simply passing the value `false` in place of the options array has the same effect as passing `array('Save' => false)`.
 
 <aside class="warning">Do not used numeric-key arrays as config values. Associative arrays are fine.</aside>
 
@@ -48,14 +48,14 @@ Simply passing the value `FALSE` in place of the options array has the same effe
 
 We've created a shortcut for making simple settings pages using the `ConfigurationModule`.
 
-The configuration module can be instantiated and rendered from any plugin. You `Initialize` it with an array of config values, each of which has its own array of properties to define it (type of field, label, default, etc). See `applications/dashboard/modules/class.configurationmodule.php` for details.
+The configuration module can be instantiated and rendered from any plugin. You `initialize` it with an array of config values, each of which has its own array of properties to define it (type of field, label, default, etc). See `applications/dashboard/modules/class.configurationmodule.php` for details.
 
 This is how the Akismet plugin uses the ConfigurationModule to build a simple settings page consisting of a text field and a dropdown:
 
 ```php
-$Cf = new ConfigurationModule($Sender);
-$Cf->Initialize(array(
-    'Plugins.Akismet.Key' => ['Description' => $KeyDesc],
+$cf = new ConfigurationModule($sender);
+$cf->initialize(array(
+    'Plugins.Akismet.Key' => ['Description' => $keyDesc],
     'Plugins.Akismet.Server' => [
         'Description' => 'You can use either Akismet or TypePad antispam.', 
         'Control' => 'DropDown', 'Items' => [
@@ -65,7 +65,7 @@ $Cf->Initialize(array(
         ]
     ]
 ));
-$Cf->RenderAll();
+$cf->renderAll();
 ```
 
 That's all there is to it - no custom view is involved.

--- a/content/developer/framework/assets.md
+++ b/content/developer/framework/assets.md
@@ -21,8 +21,8 @@ Vanilla uses these assets by default: `Head`, `Content`, `Panel`, and `Foot`. Yo
 
 ### Using assets
 
-You can create your own arbitrary assets in your templates and simply add content to them using `Gdn::controller()->addAsset('AssetName', $Content, 'ContentName')`. This is a great strategy for creating flexible themes that are easily customized by rearranging assets in the `default.master.tpl` file.
+You can create your own arbitrary assets in your templates and simply add content to them using `Gdn::controller()->addAsset('AssetName', $content, 'ContentName')`. This is a great strategy for creating flexible themes that are easily customized by rearranging assets in the `default.master.tpl` file.
 
-A common scenario is using [modules](/developer/framework/modules) to add content to an asset. (Note: In plugin hooks, you will typically be using `$Sender` in place of `Gdn::controller()` since the Sender _is_ the controller).
+A common scenario is using [modules](/developer/framework/modules) to add content to an asset. (Note: In plugin hooks, you will typically be using `$sender` in place of `Gdn::controller()` since the sender _is_ the controller).
 
 You can set the sort order in which content in an asset is displayed via the [config](/developer/configuration). Use a key like `Modules.{Application}.{Asset}` (e.g. `Modules.Vanilla.Content`) to define an array of `ContentName` values that you used when calling `addAsset()`. See `$ModuleSortContainer` in `Gdn_Controller`.

--- a/content/developer/framework/controllers.md
+++ b/content/developer/framework/controllers.md
@@ -28,11 +28,11 @@ First it looks for an application name, then a controller name, then a method na
 An example that includes all of these is: `/dashboard/profile/notifications/1/Lincoln`. This calls the Dashboard's `ProfileController` invoking the `Notifications` method, which it passes the arguments `1` and `Lincoln`, in that order. It roughly translates to:
 
 ```
-$ProfileController = new ProfileController();
-$ProfileController->notifications('1', 'Lincoln');
+$profileController = new ProfileController();
+$profileController->notifications('1', 'Lincoln');
 ```
 
-If the application is omitted, it will automatically search enabled applications for a suitably named controller. Therefore, avoid controller name overlap. If the method name is omitted, the `Index()` method will be invoked. Therefore, the basic profile URL `/profile/1/Lincoln` could be more verbosely written as `/dashboard/profile/index/1/Lincoln` to more clearly understand what code it is invoking.
+If the application is omitted, it will automatically search enabled applications for a suitably named controller. Therefore, avoid controller name overlap. If the method name is omitted, the `index()` method will be invoked. Therefore, the basic profile URL `/profile/1/Lincoln` could be more verbosely written as `/dashboard/profile/index/1/Lincoln` to more clearly understand what code it is invoking.
 
 ## Pretty URLs
 
@@ -51,7 +51,7 @@ Consult the [community](/developer/community) if you need assistance configuring
 Vanilla will attempt to detect whether your system can handle pretty URLs during installation. If it sets it incorrectly, the [config](/developer/configuration) setting to enable pretty URLs is:
 
 ```
-$Configuration['Garden']['RewriteUrls'] = TRUE;
+$Configuration['Garden']['RewriteUrls'] = true;
 ```
 The ability to use non-pretty URLs may be deprecated in the future.
 

--- a/content/developer/framework/database.md
+++ b/content/developer/framework/database.md
@@ -15,7 +15,7 @@ aliases:
 
 Vanilla only supports MySQL. It has a generic SQL driver implementation built on top of PDO to potentially allow for other databases (which you can see in `/library/databases`). However, at this time, the Vanilla team has no plans to support additional databases.
 
-The best way to access the database is via existing [models](/developer/framework/models). For instance, to get a list of discussions, use the `Get` method in the `DiscussionModel`. You can rely on model-based access to already be optimized for performance and utilize caching if it's available.
+The best way to access the database is via existing [models](/developer/framework/models). For instance, to get a list of discussions, use the `get` method in the `DiscussionModel`. You can rely on model-based access to already be optimized for performance and utilize caching if it's available.
 
 ### Building queries
 
@@ -27,15 +27,15 @@ Here's a simple example that gets a single discussion by its ID. We write its pi
 Gdn::sql()->
    ->select('*')
    ->from('Discussion')
-   ->where('DiscussionID', $DiscussionID)
+   ->where('DiscussionID', $discussionID)
    ->get();
 ```
 
 Note that this is an impractical query to use in your addon, because this functionality already exists in a model: 
 
 ```
-$DiscussionModel = new DiscussionModel();
-$DiscussionModel->getID($DiscussionID);
+$discussionModel = new DiscussionModel();
+$discussionModel->getID($discussionID);
 ```
 
 Always use pre-existing calls in models when they are available for better performance and forward-compatibility.
@@ -48,15 +48,15 @@ Gdn::sql()
    ->select('iu.Name', '', 'InsertName')
    ->from('ConversationMessage cm')
    ->join('Conversation c', 'cm.ConversationID = c.ConversationID')
-   ->join('UserConversation uc', 'c.ConversationID = uc.ConversationID and uc.UserID = '.$ViewingUserID, 'left')
+   ->join('UserConversation uc', 'c.ConversationID = uc.ConversationID and uc.UserID = '.$viewingUserID, 'left')
    ->join('User iu', 'cm.InsertUserID = iu.UserID', 'left')
    ->beginWhereGroup()
    ->where('uc.DateCleared is null')
-   ->orWhere('uc.DateCleared <', 'cm.DateInserted', TRUE, FALSE)
+   ->orWhere('uc.DateCleared <', 'cm.DateInserted', true, false)
    ->endWhereGroup()
-   ->where('cm.ConversationID', $ConversationID)
+   ->where('cm.ConversationID', $conversationID)
    ->orderBy('cm.DateInserted', 'asc')
-   ->limit($Limit, $Offset)
+   ->limit($limit, $offset)
    ->get();
 ```
 
@@ -68,17 +68,17 @@ An insert is a single step that takes the table name and an array of values to i
 
 ```
 Gdn::sql()->insert('UserConversation', array(
-   'ConversationID' => $ConversationID,
-   'UserID' => $TargetUserID
+   'ConversationID' => $conversationID,
+   'UserID' => $targetUserID
 ));
 ```
 
-An update requires setting the table in `Update`, ends with a `Put` (much like the select's ending `Get`):
+An update requires setting the table in `update`, ends with a `put` (much like the select's ending `get`):
 
 ```
 Gdn::sql()->update('Conversation')
-   ->set('LastMessageID', $MessageID)
-   ->where('ConversationID', $ConversationID)
+   ->set('LastMessageID', $messageID)
+   ->where('ConversationID', $conversationID)
    ->put();
 ```
 
@@ -98,12 +98,12 @@ Vanilla allows you to define database structures in code. Use the `Gdn::structur
 ```
 Gdn::structure()
    ->primaryKey('UserID')
-   ->column('Name', 'varchar(50)', FALSE, 'key')
+   ->column('Name', 'varchar(50)', false, 'key')
    ->column('Password', 'varbinary(100)') 
    ->column('ShowEmail', 'tinyint(1)', '0')
    ->column('Gender', array('u', 'm', 'f'), 'u')
-   ->column('Preferences', 'text', TRUE)
-   ->column('DateOfBirth', 'datetime', TRUE)
+   ->column('Preferences', 'text', true)
+   ->column('DateOfBirth', 'datetime', true)
    ->column('Score', 'float', NULL)
    ->set();
 ```
@@ -112,4 +112,4 @@ Gdn::structure()
 
 `primaryKey()` creates an auto-incrementing column. The Gender column uses an array to create an `enum` type; the rest are self-explanatory. 
 
-The `set()` method takes 2 parameters which should nearly _always_ be false, which is their default. The first is `$Explicit` which is whether to force the structure of the table to match _exactly_ the definition above. The second is `$Drop` which is whether to drop and recreate the table. 
+The `set()` method takes 2 parameters which should nearly _always_ be false, which is their default. The first is `$explicit` which is whether to force the structure of the table to match _exactly_ the definition above. The second is `$drop` which is whether to drop and recreate the table. 

--- a/content/developer/framework/datasets.md
+++ b/content/developer/framework/datasets.md
@@ -42,7 +42,7 @@ $users = Gdn::sql()
     ->where('CountComments', 1)
     ->get();
 
-foreach ($result->resultArray() as $user) {
+foreach ($users->resultArray() as $user) {
 	// Do something to each user with 1 comment.
 }
 ```

--- a/content/developer/framework/inform.md
+++ b/content/developer/framework/inform.md
@@ -29,9 +29,9 @@ An example native inform message in Vanilla: saving drafts.
 
 When a comment draft is saved, you can see an inform message appear on the bottom-left of the screen. This message shows a close button on the top-right when you hover your mouse overtop, and it automatically disappears after a few seconds. The code used to make this message appear is located on line 448 of /applications/vanilla/class.postcontroller.php:
 
-<pre lang="php">$this-&gt;InformMessage(sprintf(T('Draft saved at %s'), Gdn_Format::Date()));</pre>
+<pre lang="php">$this-&gt;informMessage(sprintf(t('Draft saved at %s'), Gdn_Format::date()));</pre>
 <p>If we didn't want to include the time that the draft was saved, we could simplify it further to:</p>
-<pre lang="php">$this-&gt;InformMessage(T('Draft saved successfully'));</pre>
+<pre lang="php">$this-&gt;informMessage(t('Draft saved successfully'));</pre>
 
 The `t()` function is Vanilla's native "Translate" function so that the string can be converted to other languages. 
 
@@ -43,9 +43,9 @@ Adding a message to the screen with a plugin.
 
 The code to achieve this is pretty easy:
 
-<pre lang="php">public function Base_Render_Before($Sender) {<br />   $Sender-&gt;InformMessage('This is a test!');<br />}</pre>
+<pre lang="php">public function base_render_before($sender) {<br />   $sender-&gt;informMessage('This is a test!');<br />}</pre>
 <p>With this code, the message will appear on every page load for every user (signed in or not) and it will disappear after a few moments. Not exactly a useful message, but let's see what else we can do with it:</p>
-<pre lang="php">public function Base_Render_Before($Sender) {<br />   // Only show the message if the user is signed in<br />   if (Gdn::Session()-&gt;IsValid())<br />      $Sender-&gt;InformMessage('This is a test!', 'Dismissable');<br />}</pre>
+<pre lang="php">public function base_render_before($sender) {<br />   // Only show the message if the user is signed in<br />   if (Gdn::session()-&gt;isValid())<br />      $sender-&gt;informMessage('This is a test!', 'Dismissable');<br />}</pre>
 
 Now the message only shows if the user has a valid session, and it doesn't auto-dismiss. The second parameter in the InformMessage method is either a string of CSS classes to be applied to the message container, or an array of options. 
 
@@ -59,7 +59,7 @@ If you don't provide the second parameter at all, it defaults to "Dismissable Au
 
 Let's say you want to deliver a message to a particular user, and have that message stay on the screen on every page load until that user dismisses the message. You can achieve it like this:
 
-<pre lang="php">public function Base_Render_Before($Sender) {<br />   $Session = Gdn::Session();<br />   if ($Session-&gt;IsValid() &amp;&amp; $Session-&gt;User-&gt;UserID == 1 &amp;&amp; $Session-&gt;GetPreference('UserDismissedCustomMessage', false) == false) {<br />      $Sender-&gt;InformMessage(<br />         'This message will stay here until you dismiss it!',<br />         array(<br />            'CssClass' =&gt; 'Dismissable',<br />            'DismissCallbackUrl' =&gt; '/plugin/dismissmessage/'<br />         )<br />      );<br />   }<br />}<br /><br />// Handle the callback<br />public function PluginController_DismissMessage_Create($Sender) {<br />   $Session = Gdn::Session();<br />   $Session-&gt;SetPreference('UserDismissedCustomMessage', TRUE);<br />}</pre>
+<pre lang="php">public function base_render_before($sender) {<br />   $session = Gdn::session();<br />   if ($session-&gt;isValid() &amp;&amp; $session-&gt;User-&gt;UserID == 1 &amp;&amp; $session-&gt;getPreference('UserDismissedCustomMessage', false) == false) {<br />      $sender-&gt;informMessage(<br />         'This message will stay here until you dismiss it!',<br />         array(<br />            'CssClass' =&gt; 'Dismissable',<br />            'DismissCallbackUrl' =&gt; '/plugin/dismissmessage/'<br />         )<br />      );<br />   }<br />}<br /><br />// Handle the callback<br />public function pluginController_dismissMessage_create($sender) {<br />   $session = Gdn::session();<br />   $session-&gt;setPreference('UserDismissedCustomMessage', true);<br />}</pre>
 
 <img style="border: 1px solid #333; margin: 20px 0; display: block;" src="http://farm6.static.flickr.com/5254/5503327977_f14304669c_o.png" alt="" /> 
 
@@ -75,7 +75,7 @@ There are over 100 icons available for you to use. You can check them out by loo
 
 Here's the code to achieve this message:
 
-<pre lang="php">$Sender-&gt;InformMessage('&lt;span class="InformSprite Skull"&gt;&lt;/span&gt; This is a test!', 'Dismissable HasSprite');</pre>
+<pre lang="php">$sender-&gt;informMessage('&lt;span class="InformSprite Skull"&gt;&lt;/span&gt; This is a test!', 'Dismissable HasSprite');</pre>
 
 Note the span at the front of the message. This will contain the "Skull" image you see above. It's also necessary for the CSS definition in the second argument to contain "HasSprite" so that the spacing &amp; alignment of the icon all works properly.
 
@@ -85,7 +85,7 @@ You can also style the inform messages to appear "From" a specific user. <img st
 
 You'll need to load a user record for the icon you wish to display, and then write the message to the screen like this:
 
-<pre lang="php">$User = Gdn::UserModel-&gt;Get(1); // Load the user who's icon you want to show<br />$String = UserPhoto($User, 'Icon'); // IMPORTANT: Give the icon a css class of "Icon" <br />$String .= 'This is a test!'; // Append some message<br />$Sender-&gt;InformMessage($String, 'Dismissable HasIcon'); // Send to the screen</pre>
+<pre lang="php">$user = Gdn::userModel()-&gt;get(1); // Load the user who's icon you want to show<br />$string = userPhoto($user, 'Icon'); // IMPORTANT: Give the icon a css class of "Icon" <br />$string .= 'This is a test!'; // Append some message<br />$sender-&gt;informMessage($string, 'Dismissable HasIcon'); // Send to the screen</pre>
 
 ## Inform via JavaScript
 

--- a/content/developer/framework/models.md
+++ b/content/developer/framework/models.md
@@ -21,34 +21,34 @@ The theory of a Model in MVC is that it is an object representation of the data 
 
 ```php
 // Create a validation object to handle validation issues that the model will encounter:
-$Validation = new Gdn_Validation();
+$validation = new Gdn_Validation();
 
 // Create a new model based on a table in the database called "Blog":
-$BlogModel = new Gdn_Model('Blog', $Validation);
+$blogModel = new Gdn_Model('Blog', $validation);
 
 // Retrieve a DataSet from the Blog table:
-$BlogData = $BlogModel->GetWhere(array('BlogID' => '12'));
+$blogData = $blogModel->getWhere(array('BlogID' => '12'));
 
 // Grab the first row of the dataset as an associative array:
-$Blog = $BlogData->FirstRow('', DATASET_TYPE_ARRAY);
+$blog = $blogData->firstRow('', DATASET_TYPE_ARRAY);
 
-// $Blog now contains every column of the "Blog" table where BlogID == 12. Let's change something:
-$Blog['Title'] = 'Some blog title';
+// $blog now contains every column of the "Blog" table where BlogID == 12. Let's change something:
+$blog['Title'] = 'Some blog title';
 
 // And save it:
-$BlogModel->Save($Blog); // Validates
+$blogModel->save($blog); // Validates
 
 // And let's try to insert something that we know shouldn't go into the database:
-$Blog['BlogID'] = 'Not an Integer!';
+$blog['BlogID'] = 'Not an Integer!';
 
 // And save it:
-$BlogModel->Save($Blog); // Doesn't validate
+$blogModel->save($blog); // Doesn't validate
 ```
 
-When the model’s “GetWhere” method is called, it does a very simple `select * from Blog where BlogID = 12`query that returns all of the columns from that table into a dataset. At this point, the model still doesn’t know anything about the structure of the table. When the model’s “Save” method is called, the first thing it does is uses the Database object to get information about the table so that it can define the table’s schema. It looks at each column’s data types, isnullable, default values, keys, etc. Then it uses the validation object to build up a set of rules for each column. Finally, it examines the \$Blog that was passed as it’s first argument, matching up associative array keys with column names, and then checks each field against the rules automatically defined for that table. As it encounters problems, it builds up a set of validation results that can then be used however you wish (typically they are consumed by Garden’s form object and displayed on the screen). So, with just a few lines of code, I’ve grabbed data from the database, altered it, and saved it - making sure that no invalid data is inserted into the database, all exceptions are caught, and results can be delivered to the user:
+When the model’s “getWhere” method is called, it does a very simple `select * from Blog where BlogID = 12`query that returns all of the columns from that table into a dataset. At this point, the model still doesn’t know anything about the structure of the table. When the model’s “save” method is called, the first thing it does is uses the Database object to get information about the table so that it can define the table’s schema. It looks at each column’s data types, isnullable, default values, keys, etc. Then it uses the validation object to build up a set of rules for each column. Finally, it examines the \$blog that was passed as it’s first argument, matching up associative array keys with column names, and then checks each field against the rules automatically defined for that table. As it encounters problems, it builds up a set of validation results that can then be used however you wish (typically they are consumed by Garden’s form object and displayed on the screen). So, with just a few lines of code, I’ve grabbed data from the database, altered it, and saved it - making sure that no invalid data is inserted into the database, all exceptions are caught, and results can be delivered to the user:
 
 ```php
-print_r($BlogModel->Validation->Results());
+print_r($blogModel->Validation->results());
 // Prints:
 Array (
     [BlogID] => Array (
@@ -61,9 +61,9 @@ This means that the "BlogID" field has encountered a problem when attempting to 
 
 ```php
 // Empty value is also incorrect
-$Blog['BlogID'] = '';
-$BlogModel->Save($Blog);
-print_r($BlogModel->Validation->Results());
+$blog['BlogID'] = '';
+$blogModel->save($blog);
+print_r($blogModel->Validation->results());
 
 // Prints:
 Array (
@@ -78,73 +78,73 @@ The validation object will always collect as much information about what is wron
 
 ## Forms & Validation
 
-In order for the database, models, validation, & datasets to shine, we need to get the information out and editable by the users. This is where the Form class comes into play. Let’s take a look at an actual example of how the controller, model, validator, and form work together. Let’s say we get the following request: `/bloggingtool/post/new` Which is the same as calling the following controller in an imaginary “bloggingtool” application: `$Post->New();`My “New” method on the post controller would contain:
+In order for the database, models, validation, & datasets to shine, we need to get the information out and editable by the users. This is where the Form class comes into play. Let’s take a look at an actual example of how the controller, model, validator, and form work together. Let’s say we get the following request: `/bloggingtool/post/new` Which is the same as calling the following controller in an imaginary “bloggingtool” application: `$post->new();`My “New” method on the post controller would contain:
 
 ```php
 public function New() {
-   $Validation = new Gdn_Validation();
-   $BlogModel = new Gdn_Model('Blog', $Validation);
+   $validation = new Gdn_Validation();
+   $blogModel = new Gdn_Model('Blog', $validation);
 
    // Set the BlogModel on the form.
-   $this->Form->SetModel($BlogModel);
+   $this->Form->setModel($blogModel);
 
    // If the form has already been posted back...
-   if ($this->Form->AuthenticatedPostBack()) {
+   if ($this->Form->authenticatedPostBack()) {
       // Attempt to save the form values
-      $BlogID = $this->Form->Save();
+      $blogID = $this->Form->save();
 
       // If it saved, redirect to the new entry:
-      if ($BlogID !== FALSE)
-         Redirect('/bloggingtool/entries/'.$BlogID);
+      if ($blogID !== false)
+         redirect('/bloggingtool/entries/'.$blogID);
 
    }
    // Render the form
-   $this->Render();
+   $this->render();
 }
 ```
 
-The form’s `Save()` method calls the model’s `Save()` and then takes any validation results that came out of it. If the save was successful, the model would have returned the id of the record inserted (or updated). If not, it could take all of the validation results and write them to the screen for the user to see. That’s really all there is to saving a bunch of data to the database. You might be wondering: **What fields were actually saved?**That all depends on what you put on the form. The Form class is a “user interface” class, which means that a large number of it’s methods actually return xhtml. The view for my “New” method above would look something like this:
+The form’s `save()` method calls the model’s `save()` and then takes any validation results that came out of it. If the save was successful, the model would have returned the id of the record inserted (or updated). If not, it could take all of the validation results and write them to the screen for the user to see. That’s really all there is to saving a bunch of data to the database. You might be wondering: **What fields were actually saved?**That all depends on what you put on the form. The Form class is a “user interface” class, which means that a large number of it’s methods actually return xhtml. The view for my “New” method above would look something like this:
 
 ```php
-echo $this->Form->Open();
-echo $this->Form->Errors();
-echo $this->Form->TextInput('Title');
-echo $this->Form->TextBox('Body');
-echo $this->Form->Close('Save');
+echo $this->Form->open();
+echo $this->Form->errors();
+echo $this->Form->textInput('Title');
+echo $this->Form->textBox('Body');
+echo $this->Form->close('Save');
 ```
 
-In this example, you can see I’ve referenced two fields on the Model that is being manipulated: *Title* and *Body*. When the form’s “Save” method is called above (and the Model’s “Save” method is called therein), the model validates and attempts to save the data. If one of these two fields were required, it would return a validation result that would then be written to the screen by `$this->Form->Errors()`. Furthermore, if there were a field on the “Blog” table that were required and not present on this form, it would have a validation result for that as well. What if we were editing a blog post instead of creating a new one?
+In this example, you can see I’ve referenced two fields on the Model that is being manipulated: *Title* and *Body*. When the form’s “save” method is called above (and the Model’s “save” method is called therein), the model validates and attempts to save the data. If one of these two fields were required, it would return a validation result that would then be written to the screen by `$this->Form->errors()`. Furthermore, if there were a field on the “Blog” table that were required and not present on this form, it would have a validation result for that as well. What if we were editing a blog post instead of creating a new one?
 
 ```php
-public function Edit($BlogID = '') {
-   $Validation = new Gdn_Validation();
-   $BlogModel = new Gdn_Model('Blog', $Validation);
+public function edit($blogID = '') {
+   $validation = new Gdn_Validation();
+   $blogModel = new Gdn_Model('Blog', $validation);
 
    // Load the blog being edited 
-   $Blog = $BlogModel ->GetWhere(array('BlogID' => $BlogID)) ->FirstRow();
+   $blog = $blogModel->getWhere(array('BlogID' => $blogID))->firstRow();
 
    // Set the BlogModel on the form.
-   $this->Form->SetModel($BlogModel);
+   $this->Form->setModel($blogModel);
 
    // Make sure the form knows which item we are editing.
-   $this->Form->AddHidden('BlogID', $BlogID);
+   $this->Form->addHidden('BlogID', $blogID);
 
    // If the form has NOT been posted back...
-   if ($this->Form->AuthenticatedPostBack() === FALSE) {
+   if ($this->Form->authenticatedPostBack() === false) {
       // Set the blog on the form
-      $this->Form->SetData($Blog);
+      $this->Form->setData($blog);
    } else {
       // Attempt to save the form values
-      $BlogID = $this->Form->Save();
+      $blogID = $this->Form->save();
 
       // If it saved, redirect to the new entry:
-      if ($BlogID !== FALSE)
-         Redirect('/bloggingtool/entries/'.$BlogID);
+      if ($blogID !== false)
+         redirect('/bloggingtool/entries/'.$blogID);
 
    }
    // Render the form
-   $this->Render();
+   $this->render();
 }
 ```
 
-I load the blog and set it’s data onto the form using `$this->Form->SetData()`. At that point the form takes over and knows to either (a) render the existing data if the form has not been posted back, or (b) render the postback data otherwise. And since I added the BlogID to the form’s hidden field collection, the model will know that it should update a blog row instead of insert a new one.
+I load the blog and set it’s data onto the form using `$this->Form->setData()`. At that point the form takes over and knows to either (a) render the existing data if the form has not been posted back, or (b) render the postback data otherwise. And since I added the BlogID to the form’s hidden field collection, the model will know that it should update a blog row instead of insert a new one.

--- a/content/developer/framework/modules.md
+++ b/content/developer/framework/modules.md
@@ -24,24 +24,24 @@ aliases:
 
 ```php
 class HelloWorldModule extends Gdn_Module {
-   public function AssetTarget() {
+   public function assetTarget() {
       return 'Panel';
    }
    
-   public function ToString() {
+   public function toString() {
       return 'Hello World!';
    }
 }
 ```
 
 
-<p>Now let's go add it to a controller. Open up a controller in your test application and add the following (if you don't have a test application, use vanilla's controllers/discussions.php file and add it to the bottom of the index method) right above the call to $this-&gt;Render():</p>
-<pre lang="php">$this-&gt;AddModule('HelloWorldModule');</pre>
+<p>Now let's go add it to a controller. Open up a controller in your test application and add the following (if you don't have a test application, use vanilla's controllers/discussions.php file and add it to the bottom of the index method) right above the call to $this-&gt;render():</p>
+<pre lang="php">$this-&gt;addModule('HelloWorldModule');</pre>
 <p>If you browse to this page, the text "Hello World!" will not appear in the panel. You can change where the "Hello World!" text appears either by changing the value returned by the AssetTarget method, or on the fly when the module is added by the controller. Let's change the AddModule call to send the module to the Content asset instead of the Panel:</p>
-<pre lang="php">$this-&gt;AddModule('HelloWorldModule', 'Content');</pre>
+<pre lang="php">$this-&gt;addModule('HelloWorldModule', 'Content');</pre>
 <p>Go back and refresh the page to see that the text has moved over to the Content asset. The AddModule method will take a string as the first parameter, or an instantiated module object. So, we could have also added the module in the following manner:</p>
-<pre lang="php">$HelloWorldModule = new HelloWorldModule();
-$this-&gt;AddModule($HelloWorldModule);</pre>
+<pre lang="php">$helloWorldModule = new HelloWorldModule();
+$this-&gt;addModule($helloWorldModule);</pre>
 <h2>Organizing Module Sort Order</h2>
 <p>You can organize the order that modules appear in assets by manipulating the Modules collection of the Configuration array. Take a look at conf/config-defaults.php to see the default sort order of core-packaged modules:</p>
 <pre lang="php">// Modules

--- a/content/developer/framework/permissions.md
+++ b/content/developer/framework/permissions.md
@@ -39,18 +39,18 @@ Other action names are avoided and may be renamed or refactored out of the frame
 
 ### Using Permissions
 
-There are two basic ways to check a permission. One is to use a true/false conditional, typically to `CheckPermission()` in an `if` statement:
+There are two basic ways to check a permission. One is to use a true/false conditional, typically to `checkPermission()` in an `if` statement:
 
 ```
-if (CheckPermission('Permission.Name')) {
+if (checkPermission('Permission.Name')) {
     // Do something special
 }
 ```
-The other is to wholesale block execution by a call to `Gdn::Session->Permission()`. This method automatically triggers a permission exception:
+The other is to wholesale block execution by a call to `Gdn::session()->permission()`. This method automatically triggers a permission exception:
 
 ```
 public function Index() {
-    Gdn::Session()->Permission('Permission.Name');
+    Gdn::session()->permission('Permission.Name');
     // Do priviliged things safely now
 }
 ```
@@ -68,7 +68,7 @@ You may find additional permission checks in Vanilla for permission names that d
 
 The forum owner's account (the one you create when installing Vanilla) gets a special flag set on it. This is accomplished by setting the `Admin` column equal to `1` in the `User` table.
 
-Accounts with this flag set bypass all permission checks. `CheckPermission` will always return `true` and no permission exception will ever be thrown for it. It will do this regardless of any role assignment.
+Accounts with this flag set bypass all permission checks. `checkPermission` will always return `true` and no permission exception will ever be thrown for it. It will do this regardless of any role assignment.
 
 For this reason, it is extremely important to test your addons with a non-owner account to see your permission checks in action.
 
@@ -80,4 +80,4 @@ This grants the same privileges as the Owner flag, and protects the account from
 
 ### Reversed Permission
 
-A special case in the framework is the `Vanilla.Approval.Require` permission. It is checked with the `CheckRequirement` function. A `true` result means their content must go to the Moderation queue for approval. Therefore, a `true` result actually grants you _less_ permission. We don't generally recommend using this construct.
+A special case in the framework is the `Vanilla.Approval.Require` permission. It is checked with the `checkRequirement` function. A `true` result means their content must go to the Moderation queue for approval. Therefore, a `true` result actually grants you _less_ permission. We don't generally recommend using this construct.

--- a/content/developer/framework/requests.md
+++ b/content/developer/framework/requests.md
@@ -49,7 +49,7 @@ You can define a `DeliveryMethod` by appending it to your request like `Delivery
 
 Vanilla parses incoming URLs and parameters for you. There is rarely any reason to directly access PHP globals like `$_GET`. The `Gdn_Request` class (in `/library/core/class.request.php`) handles this for you.
 
-`Gdn::request()->domain()` will return the current domain. These methods also work as you'd expect: `Host`, `IpAddress`, `Path`, and `Port`. You can also call `Get` and `Post` with a parameter name to see its current value. See `Gdn_Request` for more request data.
+`Gdn::request()->domain()` will return the current domain. These methods also work as you'd expect: `host`, `ipAddress`, `path`, and `port`. You can also call `get` and `post` with a parameter name to see its current value. See `Gdn_Request` for more request data.
 
 A few more useful methods:
 

--- a/content/developer/framework/views.md
+++ b/content/developer/framework/views.md
@@ -14,25 +14,25 @@ aliases:
 ---
 ## Views
 
-Once a controller method is called to handle the request, how is the xhtml of the page put together? **Views**. There are two types of views in Garden: "Views" and "Master Views". A view relates directly to the controller method that called it and handles rendering content related to that request. You can typically think of a view as the content for that page. For example, if a `Vanilla->Discussion->All()` method is called, the view for that method would handle rendering all of the discussions. Everything that is rendered around the discussions is handled by the Master View. The Master View allows you to create a consistent layout for the pages in the application. A single master view defines the look and feel and standard behavior for all of the pages (or a group of pages) in the application. Let's go back to the filesystem so you can get a better picture. In the following example, the request in the url would have been: `http://myserver.com/garden/profile/index/mark`. So, this means that Garden's "Profile" controller was requested, the "index" method was requested from the profile controller, and the first argument into the index method is "mark". In other words, the request was: `$ProfileController->Index('mark');`
+Once a controller method is called to handle the request, how is the xhtml of the page put together? **Views**. There are two types of views in Garden: "Views" and "Master Views". A view relates directly to the controller method that called it and handles rendering content related to that request. You can typically think of a view as the content for that page. For example, if a `Vanilla->Discussion->all()` method is called, the view for that method would handle rendering all of the discussions. Everything that is rendered around the discussions is handled by the Master View. The Master View allows you to create a consistent layout for the pages in the application. A single master view defines the look and feel and standard behavior for all of the pages (or a group of pages) in the application. Let's go back to the filesystem so you can get a better picture. In the following example, the request in the url would have been: `http://myserver.com/garden/profile/index/mark`. So, this means that Garden's "Profile" controller was requested, the "index" method was requested from the profile controller, and the first argument into the index method is "mark". In other words, the request was: `$profileController->index('mark');`
 
 Let's take a look at the profile controller's index method:
 
 ```php
-public function Index($UserReference = '') {
-    $UserModel = new UserModel();
-    $this->User = $UserModel->GetByReference($UserReference);
-    $this->Render();
+public function index($userReference = '') {
+    $userModel = new UserModel();
+    $this->User = $userModel->getByReference($userReference);
+    $this->render();
 }
 ```
 
-Simply put, the index method grabs some data that can be later used in the profile controller's "index" view, and then calls the `Render()` method. The Render method is defined on the base Controller class; the class from which all controllers are extended. The Render method performs the following tasks:
+Simply put, the index method grabs some data that can be later used in the profile controller's "index" view, and then calls the `render()` method. The Render method is defined on the base Controller class; the class from which all controllers are extended. The Render method performs the following tasks:
 
 1. Finds and fetches the view.
 2. Finds and fetches the css for the view.
 3. Finds and renders the master view.
 
-In the most simple example, the view will be as it appears in the image above: in a "profile" folder within the "views" folder, and named after the method that was called: `/views/profile/index.php`. By default, the controller will fetch that view from the context of the FetchView method of the base controller class. In plain-English: the view file is included within a method on the Controller class called "FetchView". That is why I placed the user data within a `$this->User` property in my `$ProfileController->Index()` method, above; so it could be accessible from within my view file. The view file likely will contain something as simple as this:
+In the most simple example, the view will be as it appears in the image above: in a "profile" folder within the "views" folder, and named after the method that was called: `/views/profile/index.php`. By default, the controller will fetch that view from the context of the FetchView method of the base controller class. In plain-English: the view file is included within a method on the Controller class called "FetchView". That is why I placed the user data within a `$this->User` property in my `$profileController->index()` method, above; so it could be accessible from within my view file. The view file likely will contain something as simple as this:
 
 ### Basic Information
 
@@ -45,10 +45,10 @@ Last Active |
 Once the view is fetched, it is added to an asset collection. By default it is added to the "Content" asset collection. The rest of the page (the "Frame" of the page) is handled by the master view. By default, the "default.master" master view is used unless another master view is specified. In the image above you can see that there are a few different master views available in the Garden application: default, email, error, and setup. The css files for each of those master views are named accordingly, as well. So, the default.master view has a default.screen.css file, the error.master view has an error.screen.css file, etc. Again, in the most simple of examples, the master view is located in the "view" folder of the application, and the related css files are located in the "design" folder of that application. Here is what the default.master view looks like:
 
 ```php
-<?php $this->RenderAsset('Head'); $BodyIdentifier, array('class' => $this->CssClass)); ?>
+<?php $this->renderAsset('Head'); $bodyIdentifier, array('class' => $this->CssClass)); ?>
 ```
 
-As you can see, the master view handles the basic structure of a page. As I mentioned above, by default the view that is fetched by the controller is added to an asset collection called "Content", and that asset collection is rendered in this master view when the `$this->RenderAsset('Content')` method is called - right there in the middle of the master view. As you can see in the master view above, there are a number of different asset collections available for application and plugin authors (Head, Menu, Content, and Foot). An application author has the ability to add as many of these as he/she desires and add to them as necessary. The idea behind these asset collections is that while the basic request can be handled and placed into the "Content" asset (ie. the profile information being displayed from the example above), there are still a lot of other elements a person may want on a page. Plugin authors may want to add assets to the head, menu, or foot. They may even want to add assets to the content collection. Garden itself has other UI components that get rendered in the head and menu asset collections (which will be discussed in a later preview). So, in the most basic example, the "index" view is requested from it's controller's view folder, the default.screen.css file is requested from the application's design folder, and the master view is requested from the root of the application's "view" folder. What other ways could the views and css have been retrieved? The controller uses Garden's FileSystem object to search the application for the appropriate file to handle the request. Whatever the filesystem object finds first, it will use.
+As you can see, the master view handles the basic structure of a page. As I mentioned above, by default the view that is fetched by the controller is added to an asset collection called "Content", and that asset collection is rendered in this master view when the `$this->renderAsset('Content')` method is called - right there in the middle of the master view. As you can see in the master view above, there are a number of different asset collections available for application and plugin authors (Head, Menu, Content, and Foot). An application author has the ability to add as many of these as he/she desires and add to them as necessary. The idea behind these asset collections is that while the basic request can be handled and placed into the "Content" asset (ie. the profile information being displayed from the example above), there are still a lot of other elements a person may want on a page. Plugin authors may want to add assets to the head, menu, or foot. They may even want to add assets to the content collection. Garden itself has other UI components that get rendered in the head and menu asset collections (which will be discussed in a later preview). So, in the most basic example, the "index" view is requested from it's controller's view folder, the default.screen.css file is requested from the application's design folder, and the master view is requested from the root of the application's "view" folder. What other ways could the views and css have been retrieved? The controller uses Garden's FileSystem object to search the application for the appropriate file to handle the request. Whatever the filesystem object finds first, it will use.
 
 ### Views are retrieved with the following precedence:
 
@@ -74,14 +74,14 @@ As you can see, the master view handles the basic structure of a page. As I ment
 You might be wondering things like: can I change the view or master view that handles my request on the fly? Of course you can! Everything in Garden was written so that you have total control over what comes out on the other end. In my example above, I could change my views on the fly with something like this:
 
 ```php
-public function Index($UserReference = '') {
-    $UserModel = new UserModel();
-    $this->User = $UserModel->GetByReference($UserReference);
+public function index($userReference = '') {
+    $userModel = new UserModel();
+    $this->User = $userModel->getByReference($userReference);
     $this->View = "somethingelse"; // Use /views/profile/somethingelse.php to handle the content
     // ... or ...
     $this->View = "/some/other/view.php"; // Use some custom view to handle the content
     $this->MasterView = "setup"; // Use the setup master view to render my contents
-    $this->Render();
+    $this->render();
 }
 ```
 

--- a/content/developer/tools/environment.md
+++ b/content/developer/tools/environment.md
@@ -68,7 +68,7 @@ if (c('Garden.Installed')) {
    saveToConfig('Cache.Memcached.Store', array('localhost:11211'));
    if (class_exists('Memcached')) {
       saveToConfig('Cache.Memcached.Option.'.Memcached::OPT_COMPRESSION, true, false);
-      saveToConfig('Cache.Memcached.Option.'.Memcached::OPT_DISTRIBUTION, Memcached::DISTRIBUTION_CONSISTENT, FALSE);
+      saveToConfig('Cache.Memcached.Option.'.Memcached::OPT_DISTRIBUTION, Memcached::DISTRIBUTION_CONSISTENT, false);
       saveToConfig('Cache.Memcached.Option.'.Memcached::OPT_LIBKETAMA_COMPATIBLE, true, false);
       saveToConfig('Cache.Memcached.Option.'.Memcached::OPT_NO_BLOCK, true, false);
       saveToConfig('Cache.Memcached.Option.'.Memcached::OPT_TCP_NODELAY, true, false);
@@ -159,6 +159,6 @@ Add a new PHP Web Application and give it the name & host of your localhost setu
 
 ![](https://us.v-cdn.net/5022541/uploads/editor/cv/1nur7d6q57eb.png "")
 
-Clicking "Play" should now open Vanilla in your browser. To prove XDebug is working, add a breakpoint to index.php at `$Dispatcher = Gdn::Dispatcher();` and click the "Bug" button. A page should open in your browser with an XDebug session attached to the URL. Back in PHPStorm, your debug console should be open with variable information.
+Clicking "Play" should now open Vanilla in your browser. To prove XDebug is working, add a breakpoint to index.php at `$dispatcher = Gdn::dispatcher();` and click the "Bug" button. A page should open in your browser with an XDebug session attached to the URL. Back in PHPStorm, your debug console should be open with variable information.
 
 *Not using PHPStorm? Add your IDE's steps here.*

--- a/content/developer/troubleshooting/index.md
+++ b/content/developer/troubleshooting/index.md
@@ -14,7 +14,7 @@ aliases:
 
 These are some generic tips for addressing problems during an upgrade.
 
-* Set `$Configuration['Debug'] = TRUE;` in your `conf/config.php` to reveal full error messages. Remember to remove it when you are done.
+* Set `$Configuration['Debug'] = true;` in your `conf/config.php` to reveal full error messages. Remember to remove it when you are done.
 * Clear your browser cache and cookies, then restart your browser.
 * Clear *.ini files from the `cache` folder.
 * Revert to the default theme. You can do this manually in `conf/config.php` by setting the `$Configuration['Garden']['Theme']` value to `default`.


### PR DESCRIPTION
Also fixes obvious code typos (wrong parenthesis or wrong variable referenced).

This should fix https://github.com/vanilla/docs/issues/262