### PR TITLE
Tweaks to embed doc metadata

### DIFF
--- a/content/developer/embeds/index.md
+++ b/content/developer/embeds/index.md
@@ -1,18 +1,16 @@
 ---
-title: Embeds
+title: Embedded Content
 tags:
 - Developers
+- Embeds
+- Load script
 category: developer
 menu:
   developer:
     identifier: embeds
-aliases:
-- /developers/embeds
 versioning:
   added: 2.7
 ---
-
-## Embeds
 
 Vanilla allows developers to develop create components that are capable of scraping content from an external site and embedding it Vanilla content using custom markup. This capability is implemented using two components: a server-side component and a client-side component.
 


### PR DESCRIPTION
A few things that I actually noticed right after I merged the initial PR and things to keep in mind for future docs.

- More tags are needed
- An alias is a redirect. It's a totally new page so we don't need it.
- If you make the first title of the page the same as the main page title, it shows up twice (The page title shows up right above the page.)
- The title is kind of overloaded with our embedding docs, so I adjusted it to make it a little bit more clear.