### PR TITLE
Update twitter redirect url documentation

### DIFF
--- a/content/help/sso/social-connect.md
+++ b/content/help/sso/social-connect.md
@@ -82,7 +82,7 @@ Twitter Connect allows users to sign in using their Twitter account. You must re
 ### Setting up social login in Twitter Connect
 
 1. Register Vanilla with Twitter at: [https://apps.twitter.com/app/new](https://apps.twitter.com/app/new)
-2. Set the Callback URL by appending `/entry/twauthorize` to the end of your forum’s URL. (If your forum is at `example.com/forum`, your Callback URL would be `http://example.com/forum/entry/twauthorize`).
+2. Set the **OAuth 2.0 Redirect URLs** by appending both `/entry/connect/twitter` and `/profile/twitterconnect` to the end of your forum’s URL. (If your forum is at `example.com/forum`, your Redirect URLs would be `http://example.com/forum/entry/connect/twitter` and `http://example.com/forum/profile/twitterconnect`).
 3. After registering, copy the "Consumer Key" and "Consumer Secret" into your Twitter plugin settings page from your Vanilla dashboard.
 
 ![Settings in Twitter](/img/help/addons/social/twitter/settings.png)


### PR DESCRIPTION
This was never correct, but twitter did not check for a correct callback_url until recently:
https://twittercommunity.com/t/action-required-sign-in-with-twitter-users-must-whitelist-callback-urls/105342