### PR TITLE
Add SteamConnect documentation

### DIFF
--- a/content/help/sso/steamconnect.md
+++ b/content/help/sso/steamconnect.md
@@ -16,7 +16,8 @@ aliases:
 
 ## SteamConnect : Overview
 
-Steam can act as an OpenID provider. This allows your application to authenticate a user's SteamID without requiring them to enter their steam username or password on your site . This is done by enabling OpenID then SteamConnect SSO addons,
+Steam can act as an OpenID provider. This allows your application to authenticate a user's SteamID without requiring 
+them to enter their steam username or password on your site . This is done by enabling OpenID then SteamConnect SSO addons,
 and configuring steamconnect via its Settings page (Dashboard → Addons → Steam Connect → Settings button).
 
 ## SteamConnect settings

--- a/content/help/sso/steamconnect.md
+++ b/content/help/sso/steamconnect.md
@@ -1,0 +1,28 @@
+---
+title: Steam Connect
+tags:
+- Features
+- Single Sign-On
+- SteamConnect
+category: help
+menu:
+  help:
+    parent: sso
+    identifier: steamconnect
+    weight: 2
+aliases:
+- /features/sso/steamconnect
+---
+
+## SteamConnect : Overview
+
+Steam can act as an OpenID provider. This allows your application to authenticate a user's SteamID without requiring them to enter their steam username or password on your site . This is done by enabling OpenID then SteamConnect SSO addons,
+and configuring steamconnect via its Settings page (Dashboard → Addons → Steam Connect → Settings button).
+
+## SteamConnect settings
+
+When creating a new SteamConnect connection you will need to fill the following field:
+
+`Steam Web API Key` you can get this key from [steam](https://steamcommunity.com/dev/apikey)
+
+[steam dev documentation](https://steamcommunity.com/dev)

--- a/content/help/sso/steamconnect.md
+++ b/content/help/sso/steamconnect.md
@@ -14,16 +14,16 @@ aliases:
 - /features/sso/steamconnect
 ---
 
-## SteamConnect : Overview
+## Overview
 
 Steam can act as an OpenID provider. This allows your application to authenticate a user's SteamID without requiring 
 them to enter their steam username or password on your site . This is done by enabling OpenID then SteamConnect SSO addons,
 and configuring steamconnect via its Settings page (Dashboard → Addons → Steam Connect → Settings button).
 
-## SteamConnect settings
+## Settings
 
 When creating a new SteamConnect connection you will need to fill the following field:
 
-`Steam Web API Key` you can get this key from [steam](https://steamcommunity.com/dev/apikey)
+`Steam Web API Key` you can get this key from [steam](https://steamcommunity.com/dev/apikey).
 
-[steam dev documentation](https://steamcommunity.com/dev)
+[steam dev documentation](https://steamcommunity.com/dev).


### PR DESCRIPTION
Closes [#647](https://github.com/vanilla/addons/issues/647)

Adds an overview document on SteamConnect plugin.