### PR TITLE
Fixed documentation on Hero Image Plugin

### DIFF
--- a/content/developer/smarty/functions.md
+++ b/content/developer/smarty/functions.md
@@ -350,7 +350,7 @@ Writes an `AdvancedSearchModule` to the page. This functionality is only the ava
 
 The advanced searchbox smarty tag does not currently offer a `placeholder` attribute. It's placeholder value can be changed by [editing the locale key](/developer/locales/) `SearchBoxPlaceHolder`.
 
-## Function `{hero_image_url}`
+## Function `{hero_image_link}`
 
 {{% cloudfeature %}}
 {{% versioning added="2.6" %}}

--- a/content/help/addons/hero-image.md
+++ b/content/help/addons/hero-image.md
@@ -62,7 +62,7 @@ A category page will return the default image (set in the [plugin's setting](#se
 The URL of the image for the current page will be made available to Smarty Templates and customize theme with the tag:
 
 ```tpl
-{hero_image_url}
+{hero_image_link}
 ```
 
 If you place this custom smarty tag in your [Customize Theme](/help/appearance/custom-theme), and disable the Hero Image plugin you site _will_ break until you either remove the tag or re-enable the plugin.
@@ -82,7 +82,7 @@ if (class_exists("HeroImagePlugin")) {
 
 The easiest way to use the hero image url is through and image tag.
 ```html
-<img src="{hero_image_url}" class="MyHeroImage"/>
+<img src="{hero_image_link}" class="MyHeroImage"/>
 ```
 
 ### Advanced Usage
@@ -90,7 +90,7 @@ Sometimes you need more flexibility than an `<img>` tag can provide. If so you c
 
 #### HTML
 ```html
-<div class="MyHero" style="background-image: url('{hero_image_url}')">
+<div class="MyHero" style="background-image: url('{hero_image_link}')">
     <h1>{$Title}</h1>
     <p>{$Description}</p>
     {breadcrumbs}


### PR DESCRIPTION
The documentation had the wrong smarty tag to fetch the hero image url.