### PR TITLE
APIV2 analytics/query : add line to explain user.userID=-1 that was added for GDPR compliance

### DIFF
--- a/content/help/apiv2/analytics.md
+++ b/content/help/apiv2/analytics.md
@@ -133,6 +133,7 @@ Valid types for the page collection are:
 Commonly used properties for the page collection are:
 
 * **user.userID**: The ID of the user, if available.  If there is no current user, either because they aren't signed in or are a guest, this value will be `0`.
+`-1` is for an anonymized user. This was added for GDPR compliance, it only shows for users in Europe.
 
 #### point
 


### PR DESCRIPTION
### Details

Running an analytics/query with the following body returns some users with user.userID = -1
This was a result of https://github.com/vanilla/analytics/pull/223 that set userid to -1 for users in Europe to be GDPR compliant.

I added a small line to explain this in the docs.
{
"type": "count",
"collection": "page",
"start": "2018-12-12",
"end": "2018-12-13",
"property": "",
"filters": [
{"prop": "type", "op": "eq", "val": "page_view"}
],
"interval": "daily",
"group": "user.userID"
}

