### PR TITLE
Replace touchConfig usage

### DIFF
--- a/content/developer/addons/theme-options.md
+++ b/content/developer/addons/theme-options.md
@@ -77,7 +77,7 @@ class MyCustomThemeHooks extends Gdn_Plugin {
      */
     public function structure() {
         // Set default theme option, but don't override it if it exists.
-        touchConfig([
+        \Gdn::config()->touch([
             "Garden.ThemeOptions.Styles.Key" => "Blue",
             "Garden.ThemeOptions.Styles.Value" => "%s_blue",
         ]);


### PR DESCRIPTION
Following https://github.com/vanilla/vanilla/pull/7960 the global `touchConfig` method is deprecated.

PR replacing usages in core: https://github.com/vanilla/vanilla/pull/8203

This PR updates `touchConfig` usage to be `Gdn::config()->touch()` instead.