### PR TITLE
Fix link from "writing api endpoints" to "resource routing"

### DIFF
--- a/content/developer/apiv2/api-endpoints.md
+++ b/content/developer/apiv2/api-endpoints.md
@@ -14,7 +14,7 @@ aliases:
 ---
 ## Controller Endpoints
 
-When writing an API controller class, each method represents an endpoint. How to define those endpoint names and parameters is covered in the [resource routing](./resource-routing) guide. This guide concerns writing the contents of a method.
+When writing an API controller class, each method represents an endpoint. How to define those endpoint names and parameters is covered in the [resource routing](/developer/apiv2/resource-routing) guide. This guide concerns writing the contents of a method.
 
 ## The Controller Base Class
 


### PR DESCRIPTION
The link to "resource routing" in the "writing api enpoints" document is wrong and gives a 404. This PR corrects that link