### PR TITLE
Analytics: Update board parameters doc when making a call to /api/v2/analytics/leaderboard

### DIFF
--- a/content/help/apiv2/analytics.md
+++ b/content/help/apiv2/analytics.md
@@ -42,8 +42,6 @@ Leaderboards are specified by the `board` parameter.  The following are valid va
  * **top-question-answerers**: Users with most answers.
  * **top-best-answerers**: Users with most accepted answers.
  * **top-member-by-total-reputation**: Users by total reputation.
- * **top-positive-users**: Users with the most positive reactions.
- * **top-member-by-accumulated-reputation**: Users by accumulated reputation.
  * **top-viewed-discussions**: Discussions with most views.
  * **top-commented-discussions**: Discussions with most comments.
  * **top-positive-discussions**: Discussions with most positive reactions.


### PR DESCRIPTION
closes [#427](https://github.com/vanilla/support/issues/427)

### Details

We do not have "top-positive-users" &  "top-member-by-accumulated-reputation" as a board parameter when making a call to [/api/v2/analytics/leaderboard](https://docs.vanillaforums.com/help/apiv2/analytics/#leaderboards).

[class.keeniotracker.php#L36](https://github.com/vanilla/analytics/blob/master/plugins/vanillaanalytics/models/class.keeniotracker.php#L36)